### PR TITLE
fix: virtual lists fixes

### DIFF
--- a/src/common/const/index.ts
+++ b/src/common/const/index.ts
@@ -1,3 +1,5 @@
 export type DefaultKeyField = typeof DEFAULT_KEY_FIELD;
 
 export const DEFAULT_KEY_FIELD = 'id';
+
+export const DEFAULT_ENTITY_KEY_FIELD = 'url';

--- a/src/common/const/index.ts
+++ b/src/common/const/index.ts
@@ -3,3 +3,5 @@ export type DefaultKeyField = typeof DEFAULT_KEY_FIELD;
 export const DEFAULT_KEY_FIELD = 'id';
 
 export const DEFAULT_ENTITY_KEY_FIELD = 'url';
+
+export const DEFAULT_PAGINATION_ITEMS_LIMIT = 120;

--- a/src/common/helpers/list.ts
+++ b/src/common/helpers/list.ts
@@ -27,3 +27,5 @@ export const createGetGroupByFirstLetter = (keyField: string = DEFAULT_ENTITY_KE
 };
 
 export const getGroupByFirstLetter = createGetGroupByFirstLetter(DEFAULT_ENTITY_KEY_FIELD);
+
+export const getGroupWithIdByFirstLetter = createGetGroupByFirstLetter('id');

--- a/src/common/helpers/list.ts
+++ b/src/common/helpers/list.ts
@@ -1,6 +1,7 @@
 import chunk from 'lodash/chunk';
 import type { TGetListRowsOptions, TListRow } from '@/types/Shared/List.types';
 import type { TName } from '@/types/Shared/BaseApiFields.types';
+import { DEFAULT_ENTITY_KEY_FIELD } from '@/common/const';
 
 export const getListRows = <Item, KeyField extends keyof Item>(
   items: Item[],
@@ -16,13 +17,13 @@ export const getListRows = <Item, KeyField extends keyof Item>(
       columns
     } as TListRow<Item, KeyField>));
 
-export const getGroupByFirstLetter = <Item extends {name: TName}>(
-  item: Item
-) => {
+export const createGetGroupByFirstLetter = (keyField: string = DEFAULT_ENTITY_KEY_FIELD) => (item: {name: TName}) => {
   const [firstLetter] = item.name.rus;
 
   return {
     name: firstLetter,
-    url: firstLetter
+    [keyField]: firstLetter
   };
 };
+
+export const getGroupByFirstLetter = createGetGroupByFirstLetter(DEFAULT_ENTITY_KEY_FIELD);

--- a/src/common/helpers/list.ts
+++ b/src/common/helpers/list.ts
@@ -1,5 +1,6 @@
 import chunk from 'lodash/chunk';
 import type { TGetListRowsOptions, TListRow } from '@/types/Shared/List.types';
+import type { TName } from '@/types/Shared/BaseApiFields.types';
 
 export const getListRows = <Item, KeyField extends keyof Item>(
   items: Item[],
@@ -14,3 +15,14 @@ export const getListRows = <Item, KeyField extends keyof Item>(
         .join(''),
       columns
     } as TListRow<Item, KeyField>));
+
+export const getGroupByFirstLetter = <Item extends {name: TName}>(
+  item: Item
+) => {
+  const [firstLetter] = item.name.rus;
+
+  return {
+    name: firstLetter,
+    url: firstLetter
+  };
+};

--- a/src/components/UI/SectionHeader.vue
+++ b/src/components/UI/SectionHeader.vue
@@ -154,10 +154,6 @@
         type: Boolean,
         default: false
       },
-      closeOnDesktop: {
-        type: Boolean,
-        default: false
-      },
       onClose: {
         type: Function,
         default: null
@@ -181,13 +177,7 @@
         || !!props.onClose
         || !!props.fullscreen);
 
-      const closeAvailable = computed(() => {
-        if (!uiStore.isMobile) {
-          return props.closeOnDesktop;
-        }
-
-        return props.onClose;
-      });
+      const closeAvailable = computed(() => props.onClose);
 
       const copyURL = () => {
         if (!clipboard.isSupported) {

--- a/src/components/list/ListRow.vue
+++ b/src/components/list/ListRow.vue
@@ -30,16 +30,16 @@
 </script>
 
 <style lang="scss" scoped>
-  $column-spacing: 12px;
+    $item-spacing: 12px;
 
   .list-row {
     display: flex;
     flex-wrap: wrap;
-    margin: -$column-spacing * .5;
+        margin: calc(-1 * var(--item-spacing, #{$item-spacing * .5}) / 2);
 
     &__column {
       flex-basis: calc(100% / v-bind(columns));
-      padding: $column-spacing * .5;
+            padding: calc(var(--item-spacing, #{$item-spacing}) / 2);
       min-width: 0;
     }
   }

--- a/src/components/list/VirtualGridList/VirtualGridList.vue
+++ b/src/components/list/VirtualGridList/VirtualGridList.vue
@@ -57,7 +57,7 @@
     columns: () => ({
       md: 1,
       xl: 2,
-      base: 4
+      base: 3
     }),
     flat: false,
     getRows: undefined

--- a/src/components/list/VirtualGridList/VirtualGridList.vue
+++ b/src/components/list/VirtualGridList/VirtualGridList.vue
@@ -1,10 +1,7 @@
 <template>
   <virtual-list
+    v-bind="list"
     :items="items"
-    :key-field="list.keyField"
-    :min-item-size="list.minItemSize"
-    :page-mode="list.pageMode"
-    class="grid-list"
   >
     <template #default="{ item: row, index, active }">
       <slot
@@ -27,6 +24,7 @@
 
 <script lang="ts" setup>
   import { computed } from 'vue';
+  import clsx from "clsx";
   import VirtualList, { TVirtualListProps } from '@/components/list/VirtualList.vue';
   import type { AnyObject } from '@/types/Shared/Utility.types';
   import ListRow, { TListRowProps } from '@/components/list/ListRow.vue';
@@ -68,6 +66,11 @@
 
   const { current: currentColumns } = useResponsiveValues({ values: columnConfig });
 
+  const list = computed<TVirtualListProps>(() => ({
+    ...props.list,
+    getItemClass: (item: TItem) => clsx(props.list.getItemClass?.(item), "virtual-grid-list__item")
+  }));
+
   const items = computed(() => (props.getRows
     ? props.getRows(props.list.items, {
       columns: currentColumns.value,
@@ -80,12 +83,12 @@
 </script>
 
 <style lang="scss" scoped>
-  .grid-list :deep {
+    :deep {
     .vue-recycle-scroller__item-view {
       margin: 0;
       padding: 0;
 
-      > .item {
+            > .virtual-grid-list__item {
         padding-bottom: 0;
       }
     }

--- a/src/components/list/VirtualGridList/VirtualGridList.vue
+++ b/src/components/list/VirtualGridList/VirtualGridList.vue
@@ -83,12 +83,12 @@
 </script>
 
 <style lang="scss" scoped>
-    :deep {
+  :deep {
     .vue-recycle-scroller__item-view {
       margin: 0;
       padding: 0;
 
-            > .virtual-grid-list__item {
+      > .virtual-grid-list__item {
         padding-bottom: 0;
       }
     }

--- a/src/components/list/VirtualGridList/VirtualGridList.vue
+++ b/src/components/list/VirtualGridList/VirtualGridList.vue
@@ -25,14 +25,15 @@
 <script lang="ts" setup>
   import { computed } from 'vue';
   import clsx from "clsx";
-  import VirtualList, { TVirtualListProps } from '@/components/list/VirtualList.vue';
-  import type { AnyObject } from '@/types/Shared/Utility.types';
+  import VirtualList from '@/components/list/VirtualList/VirtualList.vue';
+  import type { AnyObject, RecordKey } from '@/types/Shared/Utility.types';
   import ListRow, { TListRowProps } from '@/components/list/ListRow.vue';
   import { DEFAULT_KEY_FIELD } from '@/common/const';
   import type { TResponsiveValues } from '@/common/composition/useResponsiveValues';
   import { useResponsiveValues } from '@/common/composition/useResponsiveValues';
   import { getListRows } from '@/common/helpers/list';
   import type { TListRow } from '@/types/Shared/List.types';
+  import type { TVirtualListProps } from "@/components/list/VirtualList/types";
 
   /* TODO: Добавить generic-типизацию по выходу Vue 3.3 */
   type TItem = AnyObject;
@@ -48,7 +49,7 @@
     list: TVirtualListProps;
     columns?: TResponsiveValues<number>;
     flat?: boolean;
-    getRows?: (items: TItem[], context: TVirtualGridListContext) => TListRow<TItem, typeof props.list.keyField>[];
+    getRows?: (items: TItem[], context: TVirtualGridListContext) => TListRow<TItem, RecordKey>[];
   }
 
   const props = withDefaults(defineProps<TProps>(), {
@@ -68,7 +69,7 @@
 
   const list = computed<TVirtualListProps>(() => ({
     ...props.list,
-    getItemClass: (item: TItem) => clsx(props.list.getItemClass?.(item), "virtual-grid-list__item")
+    getItemClass: (item: unknown) => clsx(props.list.getItemClass?.(item), "virtual-grid-list__item")
   }));
 
   const items = computed(() => (props.getRows

--- a/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
+++ b/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
@@ -1,5 +1,6 @@
 <template>
   <virtual-grid-list
+    class="virtual-grouped-list"
     :get-rows="getRows"
     :list="list"
     v-bind="grid"
@@ -32,6 +33,8 @@
 <script lang="ts" setup>
   import uniqBy from 'lodash/uniqBy';
   import sortBy from 'lodash/sortBy';
+  import { computed } from "vue";
+  import clsx from "clsx";
   import { TVirtualListProps } from '@/components/list/VirtualList.vue';
   import GroupedListCategory from '@/components/list/GroupedListCategory.vue';
   import type { AnyObject } from '@/types/Shared/Utility.types';
@@ -62,6 +65,13 @@
     sortBy: 'order'
   });
 
+  const list = computed<TVirtualListProps>(() => ({
+    ...props.list,
+    getItemClass: (item: TItem) => clsx(props.list.getItemClass?.(item), {
+      "virtual-grouped-list__group": item.isGroup
+    })
+  }));
+
   const getRows: TVirtualGridListProps['getRows'] = (items: TItem[], context: TVirtualGridListContext) => {
     const {
       keyField,
@@ -79,3 +89,13 @@
     });
   };
 </script>
+
+<style lang="scss" scoped>
+    .virtual-grouped-list :deep {
+        .vue-recycle-scroller__item-view {
+            > .virtual-grouped-list__group {
+                padding-bottom: var(--item-spacing);
+            }
+        }
+    }
+</style>

--- a/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
+++ b/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
@@ -92,16 +92,16 @@
 </script>
 
 <style lang="scss" scoped>
-    .virtual-grouped-list :deep {
-        --group-spacing: calc(var(--item-spacing) * 2);
-        // Добавляем отрицательный margin для родителя, чтобы не было лишнего отступа
-        margin-top: calc(-1 * var(--group-spacing));
+  .virtual-grouped-list :deep {
+    --group-spacing: calc(var(--item-spacing) * 2);
+    // Добавляем отрицательный margin для родителя, чтобы не было лишнего отступа
+    margin-top: calc(-1 * var(--group-spacing));
 
-        .vue-recycle-scroller__item-view {
-            > .virtual-grouped-list__group {
-                padding-top: var(--group-spacing);
-                padding-bottom: var(--item-spacing);
-            }
-        }
+    .vue-recycle-scroller__item-view {
+      > .virtual-grouped-list__group {
+        padding-top: var(--group-spacing);
+        padding-bottom: var(--item-spacing);
+      }
     }
+  }
 </style>

--- a/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
+++ b/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
@@ -35,7 +35,6 @@
   import sortBy from 'lodash/sortBy';
   import { computed } from "vue";
   import clsx from "clsx";
-  import { TVirtualListProps } from '@/components/list/VirtualList.vue';
   import GroupedListCategory from '@/components/list/GroupedListCategory.vue';
   import type { AnyObject } from '@/types/Shared/Utility.types';
   import type { ListIteratee } from '@/types/Shared/Lodash.types';
@@ -47,6 +46,7 @@
     TVirtualGridListProps
   } from '@/components/list/VirtualGridList/VirtualGridList.vue';
   import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import type { TVirtualListProps } from "@/components/list/VirtualList/types";
 
   /* TODO: Добавить generic-типизацию по выходу Vue 3.3 */
   type TItem = AnyObject;
@@ -68,7 +68,9 @@
 
   const list = computed<TVirtualListProps>(() => ({
     ...props.list,
-    getItemClass: (item: TItem) => clsx(props.list.getItemClass?.(item), {
+
+    /* TODO: Типизировать через дженерики и убрать any */
+    getItemClass: (item: any) => clsx(props.list.getItemClass?.(item), {
       "virtual-grouped-list__group": item.isGroup
     })
   }));

--- a/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
+++ b/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
@@ -93,8 +93,13 @@
 
 <style lang="scss" scoped>
     .virtual-grouped-list :deep {
+        --group-spacing: calc(var(--item-spacing) * 2);
+        // Добавляем отрицательный margin для родителя, чтобы не было лишнего отступа
+        margin-top: calc(-1 * var(--group-spacing));
+
         .vue-recycle-scroller__item-view {
             > .virtual-grouped-list__group {
+                padding-top: var(--group-spacing);
                 padding-bottom: var(--item-spacing);
             }
         }

--- a/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
+++ b/src/components/list/VirtualGroupedList/VirtualGroupedList.vue
@@ -57,12 +57,13 @@
     getGroup: TGetGroup<TItem, TGroup>;
     groupLabelKey?: string;
     sortBy?: ListIteratee;
-    grid: TVirtualGridListProps;
+    grid?: TVirtualGridListProps;
   };
 
   const props = withDefaults(defineProps<TProps>(), {
-    groupLabelKey: 'name',
-    sortBy: 'order'
+    groupLabelKey: "name",
+    sortBy: "order",
+    grid: () => ({})
   });
 
   const list = computed<TVirtualListProps>(() => ({

--- a/src/components/list/VirtualList.vue
+++ b/src/components/list/VirtualList.vue
@@ -1,8 +1,9 @@
 <template>
   <dynamic-scroller
-    item-tag="li"
-    list-tag="ul"
     v-bind="props"
+    class="virtual-list"
+    list-tag="ul"
+    item-tag="li"
   >
     <template #default="{ item, index, active }">
       <dynamic-scroller-item
@@ -10,7 +11,7 @@
         :active="active"
         :data-index="index"
         :item="item"
-        class="item"
+        :class="getItemClasses(item)"
       >
         <slot v-bind="{ item, index, active }" />
       </dynamic-scroller-item>
@@ -20,7 +21,9 @@
 
 <script lang="ts" setup>
   import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
+  import clsx from "clsx";
   import { DEFAULT_KEY_FIELD } from '@/common/const';
+  import type { Maybe } from "@/types/Shared/Utility.types";
 
   /* TODO: Добавить generic-типизацию по выходу Vue 3.3 */
 
@@ -29,21 +32,30 @@
     keyField?: string,
     minItemSize?: number;
     pageMode?: boolean;
+    getItemClass?: (item: unknown) => Maybe<string>;
   };
 
   const props = withDefaults(defineProps<TVirtualListProps>(), {
     keyField: DEFAULT_KEY_FIELD,
     pageMode: true,
-    minItemSize: 55
+    minItemSize: 55,
+    getItemClass: () => undefined
   });
+
+  const getItemClasses = (item: unknown) => clsx('virtual-list__item', props.getItemClass?.(item));
 </script>
 
 <style lang="scss" scoped>
   $item-spacing: 12px;
 
+    .virtual-list {
+        --item-spacing: #{$item-spacing};
+    }
+
   :deep {
     &.vue-recycle-scroller {
-      margin-bottom: -$item-spacing;
+            // Добавляем отрицательный margin для родителя, чтобы не было лишнего отступа
+            margin-bottom: calc(-1 * var(--item-spacing, #{$item-spacing}));
     }
 
     .vue-recycle-scroller__item-wrapper {
@@ -55,8 +67,9 @@
       margin: 0;
       padding: 0;
 
-      > .item {
-        padding-bottom: $item-spacing;
+            // Добавляем отступ между элементами
+            > .virtual-list__item {
+                padding-bottom: var(--item-spacing, #{$item-spacing})
       }
     }
   }

--- a/src/components/list/VirtualList.vue
+++ b/src/components/list/VirtualList.vue
@@ -1,6 +1,6 @@
 <template>
   <dynamic-scroller
-    v-bind="props"
+    v-bind="scrollerProps"
     class="virtual-list"
     list-tag="ul"
     item-tag="li"
@@ -22,6 +22,7 @@
 <script lang="ts" setup>
   import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
   import clsx from "clsx";
+  import { computed } from "vue";
   import { DEFAULT_KEY_FIELD } from '@/common/const';
   import type { Maybe } from "@/types/Shared/Utility.types";
 
@@ -40,6 +41,12 @@
     pageMode: true,
     minItemSize: 55,
     getItemClass: () => undefined
+  });
+
+  const scrollerProps = computed(() => {
+    const { getItemClass, ...rest } = props;
+
+    return rest;
   });
 
   const getItemClasses = (item: unknown) => clsx('virtual-list__item', props.getItemClass?.(item));

--- a/src/components/list/VirtualList.vue
+++ b/src/components/list/VirtualList.vue
@@ -55,14 +55,14 @@
 <style lang="scss" scoped>
   $item-spacing: 12px;
 
-    .virtual-list {
-        --item-spacing: #{$item-spacing};
-    }
+  .virtual-list {
+    --item-spacing: #{$item-spacing};
+  }
 
   :deep {
     &.vue-recycle-scroller {
-            // Добавляем отрицательный margin для родителя, чтобы не было лишнего отступа
-            margin-bottom: calc(-1 * var(--item-spacing, #{$item-spacing}));
+      // Добавляем отрицательный margin для родителя, чтобы не было лишнего отступа
+      margin-bottom: calc(-1 * var(--item-spacing, #{$item-spacing}));
     }
 
     .vue-recycle-scroller__item-wrapper {
@@ -74,9 +74,9 @@
       margin: 0;
       padding: 0;
 
-            // Добавляем отступ между элементами
-            > .virtual-list__item {
-                padding-bottom: var(--item-spacing, #{$item-spacing})
+      // Добавляем отступ между элементами
+      > .virtual-list__item {
+        padding-bottom: var(--item-spacing, #{$item-spacing})
       }
     }
   }

--- a/src/components/list/VirtualList/VirtualList.vue
+++ b/src/components/list/VirtualList/VirtualList.vue
@@ -24,17 +24,7 @@
   import clsx from "clsx";
   import { computed } from "vue";
   import { DEFAULT_KEY_FIELD } from '@/common/const';
-  import type { Maybe } from "@/types/Shared/Utility.types";
-
-  /* TODO: Добавить generic-типизацию по выходу Vue 3.3 */
-
-  export type TVirtualListProps = {
-    items: unknown[];
-    keyField?: string,
-    minItemSize?: number;
-    pageMode?: boolean;
-    getItemClass?: (item: unknown) => Maybe<string>;
-  };
+  import type { TVirtualListProps } from "@/components/list/VirtualList/types";
 
   const props = withDefaults(defineProps<TVirtualListProps>(), {
     keyField: DEFAULT_KEY_FIELD,

--- a/src/components/list/VirtualList/helpers.ts
+++ b/src/components/list/VirtualList/helpers.ts
@@ -1,0 +1,7 @@
+import type { TVirtualListProps } from '@/components/list/VirtualList/types';
+import { DEFAULT_ENTITY_KEY_FIELD } from '@/common/const';
+
+export const getListProps = (base: TVirtualListProps): TVirtualListProps => ({
+  keyField: DEFAULT_ENTITY_KEY_FIELD,
+  ...base
+});

--- a/src/components/list/VirtualList/types.ts
+++ b/src/components/list/VirtualList/types.ts
@@ -1,0 +1,9 @@
+import type { AnyObject, Maybe } from '@/types/Shared/Utility.types';
+
+export type TVirtualListProps = {
+  items: AnyObject[];
+  keyField?: string,
+  minItemSize?: number;
+  pageMode?: boolean;
+  getItemClass?: (item: unknown) => Maybe<string>;
+};

--- a/src/views/Character/Backgrounds/BackgroundDetail.vue
+++ b/src/views/Character/Backgrounds/BackgroundDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="background-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="background?.name?.eng || ''"

--- a/src/views/Character/Backgrounds/BackgroundsView.vue
+++ b/src/views/Character/Backgrounds/BackgroundsView.vue
@@ -7,8 +7,8 @@
     @update="initPages"
   >
     <virtual-grid-list
+      :list="{ items: backgrounds, keyField: DEFAULT_ENTITY_KEY_FIELD, minItemSize: 50 }"
       :flat="showRightSide"
-      :list="{ items: backgrounds, keyField: 'url', minItemSize: 50 }"
     >
       <template #default="{ item: background }">
         <background-link
@@ -31,6 +31,7 @@
   import { usePagination } from '@/common/composition/usePagination';
   import { BackgroundsFilterDefaults } from '@/types/Character/Backgrounds.types';
   import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Character/Backgrounds/BackgroundsView.vue
+++ b/src/views/Character/Backgrounds/BackgroundsView.vue
@@ -6,9 +6,10 @@
     @search="onSearch"
     @update="initPages"
   >
-    <virtual-grid-list
+    <virtual-grouped-list
       :list="{ items: backgrounds, keyField: DEFAULT_ENTITY_KEY_FIELD, minItemSize: 50 }"
-      :flat="showRightSide"
+      :get-group="getGroupByFirstLetter"
+      :grid="{ flat: showRightSide }"
     >
       <template #default="{ item: background }">
         <background-link
@@ -16,7 +17,7 @@
           :to="{ path: background.url }"
         />
       </template>
-    </virtual-grid-list>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
@@ -30,8 +31,9 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { BackgroundsFilterDefaults } from '@/types/Character/Backgrounds.types';
-  import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
   import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
+  import { getGroupByFirstLetter } from "@/common/helpers/list";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Character/Backgrounds/BackgroundsView.vue
+++ b/src/views/Character/Backgrounds/BackgroundsView.vue
@@ -7,7 +7,7 @@
     @update="initPages"
   >
     <virtual-grouped-list
-      :list="{ items: backgrounds, keyField: DEFAULT_ENTITY_KEY_FIELD, minItemSize: 50 }"
+      :list="getListProps({ items: backgrounds, minItemSize: 50 })"
       :get-group="getGroupByFirstLetter"
       :grid="{ flat: showRightSide }"
     >
@@ -31,9 +31,9 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { BackgroundsFilterDefaults } from '@/types/Character/Backgrounds.types';
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import { getGroupByFirstLetter } from "@/common/helpers/list";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Character/Backgrounds/BackgroundsView.vue
+++ b/src/views/Character/Backgrounds/BackgroundsView.vue
@@ -76,10 +76,6 @@
   onBeforeMount(async () => {
     await filter.initFilter();
     await initPages();
-
-    if (!isMobile.value && backgrounds.value.length && route.name === 'backgrounds') {
-      await router.push({ path: backgrounds.value[0].url });
-    }
   });
 
   const showRightSide = computed(() => route.name === 'backgroundDetail');

--- a/src/views/Character/Classes/ClassDetail.vue
+++ b/src/views/Character/Classes/ClassDetail.vue
@@ -6,7 +6,6 @@
         :subtitle="currentClass?.name?.eng || ''"
         :title="currentClass?.name?.rus || ''"
         bookmark
-        close-on-desktop
         fullscreen
         print
         @close="close"

--- a/src/views/Character/Options/OptionDetail.vue
+++ b/src/views/Character/Options/OptionDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="option-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="option?.name?.eng || ''"

--- a/src/views/Character/Options/OptionsView.vue
+++ b/src/views/Character/Options/OptionsView.vue
@@ -9,7 +9,7 @@
     @list-end="nextPage"
   >
     <virtual-grouped-list
-      :list="{ items: options, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :list="getListProps({ items: options })"
       :grid="{ flat: showRightSide }"
       :get-group="getGroupByFirstLetter"
     >
@@ -38,8 +38,9 @@
   import { usePagination } from '@/common/composition/usePagination';
   import { OptionsFilterDefaults } from '@/types/Character/Options.types';
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
-  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
+  import { DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
   import { getGroupByFirstLetter } from "@/common/helpers/list";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   type TProps = {
     inTab?: boolean,

--- a/src/views/Character/Options/OptionsView.vue
+++ b/src/views/Character/Options/OptionsView.vue
@@ -8,9 +8,10 @@
     @update="initPages"
     @list-end="nextPage"
   >
-    <virtual-grid-list
-      :flat="showRightSide"
-      :list="{ items: options, keyField: 'url' }"
+    <virtual-grouped-list
+      :list="{ items: options, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :grid="{ flat: showRightSide }"
+      :get-group="getGroupByFirstLetter"
     >
       <template #default="{ item: option }">
         <option-link
@@ -19,7 +20,7 @@
           :to="{ path: option.url }"
         />
       </template>
-    </virtual-grid-list>
+    </virtual-grouped-list>
   </component>
 </template>
 
@@ -36,7 +37,9 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { OptionsFilterDefaults } from '@/types/Character/Options.types';
-  import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { getGroupByFirstLetter } from "@/common/helpers/list";
 
   type TProps = {
     inTab?: boolean,

--- a/src/views/Character/Options/OptionsView.vue
+++ b/src/views/Character/Options/OptionsView.vue
@@ -118,10 +118,6 @@
   onBeforeMount(async () => {
     await filter.initFilter();
     await initPages();
-
-    if (!isMobile.value && options.value.length && route.name === 'options') {
-      await router.push({ path: options.value[0].url });
-    }
   });
 
   watch(

--- a/src/views/Character/Options/OptionsView.vue
+++ b/src/views/Character/Options/OptionsView.vue
@@ -38,7 +38,7 @@
   import { usePagination } from '@/common/composition/usePagination';
   import { OptionsFilterDefaults } from '@/types/Character/Options.types';
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
   import { getGroupByFirstLetter } from "@/common/helpers/list";
 
   type TProps = {
@@ -96,7 +96,7 @@
     items: options
   } = usePagination({
     url: '/options',
-    limit: 120,
+    limit: DEFAULT_PAGINATION_ITEMS_LIMIT,
     filter: {
       isCustomized,
       value: queryParams

--- a/src/views/Character/Options/OptionsView.vue
+++ b/src/views/Character/Options/OptionsView.vue
@@ -96,7 +96,7 @@
     items: options
   } = usePagination({
     url: '/options',
-    limit: 70,
+    limit: 120,
     filter: {
       isCustomized,
       value: queryParams

--- a/src/views/Character/Races/RaceDetail.vue
+++ b/src/views/Character/Races/RaceDetail.vue
@@ -6,7 +6,6 @@
         :subtitle="race?.name?.eng || ''"
         :title="race?.name?.rus || ''"
         bookmark
-        close-on-desktop
         fullscreen
         print
         @close="close"

--- a/src/views/Character/Spells/SpellDetail.vue
+++ b/src/views/Character/Spells/SpellDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="spell-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="spell?.name?.eng || ''"

--- a/src/views/Character/Spells/SpellsView.vue
+++ b/src/views/Character/Spells/SpellsView.vue
@@ -137,10 +137,6 @@
       onBeforeMount(async () => {
         await filter.initFilter();
         await initPages();
-
-        if (!isMobile.value && spells.value.length && route.name === 'spells') {
-          await router.push({ path: spells.value[0].url });
-        }
       });
 
       watch(

--- a/src/views/Character/Spells/SpellsView.vue
+++ b/src/views/Character/Spells/SpellsView.vue
@@ -9,9 +9,9 @@
     @list-end="nextPage"
   >
     <virtual-grouped-list
+      :list="{ items: spells, keyField: DEFAULT_ENTITY_KEY_FIELD }"
       :get-group="getSpellGroup"
       :grid="{ flat: showRightSide }"
-      :list="{ items: spells, keyField: 'url' }"
     >
       <template #default="{ item: spell }">
         <spell-link
@@ -40,6 +40,7 @@
   import { SpellsFilterDefaults } from '@/types/Character/Spells.types';
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
   import type { AnyObject } from '@/types/Shared/Utility.types';
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   export default defineComponent({
     components: {
@@ -174,7 +175,8 @@
         initPages,
         nextPage,
         onSearch,
-        getSpellGroup
+        getSpellGroup,
+        DEFAULT_ENTITY_KEY_FIELD
       };
     }
   });

--- a/src/views/Character/Spells/SpellsView.vue
+++ b/src/views/Character/Spells/SpellsView.vue
@@ -40,7 +40,7 @@
   import { SpellsFilterDefaults } from '@/types/Character/Spells.types';
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
   import type { AnyObject } from '@/types/Shared/Utility.types';
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
 
   export default defineComponent({
     components: {
@@ -109,7 +109,7 @@
         items: spells
       } = usePagination({
         url: '/spells',
-        limit: 120,
+        limit: DEFAULT_PAGINATION_ITEMS_LIMIT,
         filter: {
           isCustomized,
           value: queryParams

--- a/src/views/Character/Spells/SpellsView.vue
+++ b/src/views/Character/Spells/SpellsView.vue
@@ -109,7 +109,7 @@
         items: spells
       } = usePagination({
         url: '/spells',
-        limit: 70,
+        limit: 120,
         filter: {
           isCustomized,
           value: queryParams

--- a/src/views/Character/Spells/SpellsView.vue
+++ b/src/views/Character/Spells/SpellsView.vue
@@ -9,7 +9,7 @@
     @list-end="nextPage"
   >
     <virtual-grouped-list
-      :list="{ items: spells, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :list="getListProps({ items: spells })"
       :get-group="getSpellGroup"
       :grid="{ flat: showRightSide }"
     >
@@ -41,6 +41,7 @@
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
   import type { AnyObject } from '@/types/Shared/Utility.types';
   import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   export default defineComponent({
     components: {
@@ -178,6 +179,7 @@
         getSpellGroup,
         DEFAULT_ENTITY_KEY_FIELD
       };
-    }
+    },
+    methods: { getListProps }
   });
 </script>

--- a/src/views/Character/Traits/TraitDetail.vue
+++ b/src/views/Character/Traits/TraitDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="trait-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="trait?.name?.eng || ''"

--- a/src/views/Character/Traits/TraitsView.vue
+++ b/src/views/Character/Traits/TraitsView.vue
@@ -8,7 +8,7 @@
   >
     <virtual-grouped-list
       :list="{ items: traits, keyField: 'url' }"
-      :get-group="getTraitGroup"
+      :get-group="getGroupByFirstLetter"
       :grid="{ flat: showRightSide }"
     >
       <template #default="{ item: trait }">
@@ -32,7 +32,7 @@
   import { usePagination } from '@/common/composition/usePagination';
   import { TraitsFilterDefaults } from '@/types/Character/Traits.types';
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
-  import type { AnyObject } from "@/types/Shared/Utility.types";
+  import { getGroupByFirstLetter } from "@/common/helpers/list";
 
   type TProps = {
     storeKey?: string;
@@ -81,16 +81,6 @@
     if (traits.value.length === 1 && !isMobile.value) {
       await router.push({ path: traits.value[0].url });
     }
-  };
-
-  /* TODO: Добавить тип черты */
-  const getTraitGroup = (trait: AnyObject & {name: Record<string, unknown[]>}) => {
-    const [firstLetter] = trait.name.rus;
-
-    return {
-      name: firstLetter,
-      url: firstLetter
-    };
   };
 
   onBeforeMount(async () => {

--- a/src/views/Character/Traits/TraitsView.vue
+++ b/src/views/Character/Traits/TraitsView.vue
@@ -7,7 +7,7 @@
     @update="initPages"
   >
     <virtual-grouped-list
-      :list="{ items: traits, keyField: 'url' }"
+      :list="{ items: traits, keyField: DEFAULT_ENTITY_KEY_FIELD }"
       :get-group="getGroupByFirstLetter"
       :grid="{ flat: showRightSide }"
     >
@@ -33,6 +33,7 @@
   import { TraitsFilterDefaults } from '@/types/Character/Traits.types';
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
   import { getGroupByFirstLetter } from "@/common/helpers/list";
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   type TProps = {
     storeKey?: string;

--- a/src/views/Character/Traits/TraitsView.vue
+++ b/src/views/Character/Traits/TraitsView.vue
@@ -84,10 +84,6 @@
   onBeforeMount(async () => {
     await filter.initFilter();
     await initPages();
-
-    if (!isMobile.value && traits.value.length && route.name === 'traits') {
-      await router.push({ path: traits.value[0].url });
-    }
   });
 
   const showRightSide = computed(() => route.name === 'traitDetail');

--- a/src/views/Character/Traits/TraitsView.vue
+++ b/src/views/Character/Traits/TraitsView.vue
@@ -7,7 +7,7 @@
     @update="initPages"
   >
     <virtual-grouped-list
-      :list="{ items: traits, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :list="getListProps({ items: traits })"
       :get-group="getGroupByFirstLetter"
       :grid="{ flat: showRightSide }"
     >
@@ -33,7 +33,7 @@
   import { TraitsFilterDefaults } from '@/types/Character/Traits.types';
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
   import { getGroupByFirstLetter } from "@/common/helpers/list";
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   type TProps = {
     storeKey?: string;

--- a/src/views/Character/Traits/TraitsView.vue
+++ b/src/views/Character/Traits/TraitsView.vue
@@ -6,9 +6,10 @@
     @search="onSearch"
     @update="initPages"
   >
-    <virtual-grid-list
-      :flat="showRightSide"
+    <virtual-grouped-list
       :list="{ items: traits, keyField: 'url' }"
+      :get-group="getTraitGroup"
+      :grid="{ flat: showRightSide }"
     >
       <template #default="{ item: trait }">
         <trait-link
@@ -16,7 +17,7 @@
           :trait-item="trait"
         />
       </template>
-    </virtual-grid-list>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
@@ -30,7 +31,8 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { TraitsFilterDefaults } from '@/types/Character/Traits.types';
-  import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
+  import type { AnyObject } from "@/types/Shared/Utility.types";
 
   type TProps = {
     storeKey?: string;
@@ -79,6 +81,16 @@
     if (traits.value.length === 1 && !isMobile.value) {
       await router.push({ path: traits.value[0].url });
     }
+  };
+
+  /* TODO: Добавить тип черты */
+  const getTraitGroup = (trait: AnyObject & {name: Record<string, unknown[]>}) => {
+    const [firstLetter] = trait.name.rus;
+
+    return {
+      name: firstLetter,
+      url: firstLetter
+    };
   };
 
   onBeforeMount(async () => {

--- a/src/views/Inventory/Armors/ArmorDetail.vue
+++ b/src/views/Inventory/Armors/ArmorDetail.vue
@@ -2,7 +2,6 @@
   <content-detail>
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :fullscreen="!isMobile"
         :subtitle="armor?.name?.eng"
         :title="armor?.name?.rus"

--- a/src/views/Inventory/Armors/ArmorsView.vue
+++ b/src/views/Inventory/Armors/ArmorsView.vue
@@ -113,10 +113,6 @@
 
       onBeforeMount(async () => {
         await initPages();
-
-        if (!isMobile.value && armors.value.length && route.name === 'armors') {
-          await router.push({ path: armors.value[0].list[0].url });
-        }
       });
 
       return {

--- a/src/views/Inventory/Armors/ArmorsView.vue
+++ b/src/views/Inventory/Armors/ArmorsView.vue
@@ -6,32 +6,23 @@
     @search="onSearch"
     @update="initPages"
   >
-    <div
-      v-for="(group, groupKey) in armors"
-      :key="groupKey"
-      class="armors-group"
+    <virtual-grouped-list
+      :grid="{ flat: showRightSide }"
+      :get-group="getArmorGroup"
+      :list="{ items: armors, keyField: 'url' }"
     >
-      <div class="armors-group__name">
-        {{ group.name }}
-      </div>
-
-      <div class="armors-group__list">
+      <template #default="{ item: armor }">
         <armor-link
-          v-for="armor in group.list"
-          :key="armor.url"
           :armor="armor"
           :to="{ path: armor.url }"
         />
-      </div>
-    </div>
+      </template>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
-<script lang="ts">
-  import {
-    computed, defineComponent, onBeforeMount
-  } from 'vue';
-  import sortBy from 'lodash/sortBy';
+<script lang="ts" setup>
+  import { computed, onBeforeMount } from 'vue';
   import { storeToRefs } from 'pinia';
   import { useRoute, useRouter } from 'vue-router';
   import ContentLayout from '@/components/content/ContentLayout.vue';
@@ -40,90 +31,55 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { ArmorsFilterDefaults } from '@/types/Inventory/Armors.types';
+  import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
+  import type { AnyObject } from "@/types/Shared/Utility.types";
 
-  export default defineComponent({
-    components: {
-      ArmorLink,
-      ContentLayout
-    },
-    setup() {
-      const route = useRoute();
-      const router = useRouter();
-      const uiStore = useUIStore();
+  const route = useRoute();
+  const router = useRouter();
+  const uiStore = useUIStore();
 
-      const {
-        isMobile,
-        fullscreen
-      } = storeToRefs(uiStore);
+  const {
+    isMobile,
+    fullscreen
+  } = storeToRefs(uiStore);
 
-      const filter = useFilter({
-        dbName: ArmorsFilterDefaults.dbName,
-        url: ArmorsFilterDefaults.url
-      });
-
-      const {
-        initPages,
-        items
-      } = usePagination({
-        url: '/armors',
-        limit: -1,
-        search: filter.search,
-        order: [
-          {
-            field: 'AC',
-            direction: 'asc'
-          }
-        ]
-      });
-
-      // TODO: Доделать типизацию
-      const armors = computed(() => {
-        const list: any = [];
-        const types: any = [];
-
-        if (!items.value) {
-          return list;
-        }
-
-        for (const armor of items.value) {
-          if (types.find((obj: any) => obj.name === armor.type.name)) {
-            continue;
-          }
-
-          types.push(armor.type);
-        }
-
-        for (const type of sortBy(types, [o => o.order])) {
-          list.push({
-            name: type.name,
-            list: items.value.filter(armor => armor.type.name === type.name)
-          });
-        }
-
-        return list;
-      });
-
-      const onSearch = async () => {
-        await initPages();
-
-        if (armors.value.length === 1 && !isMobile.value) {
-          await router.push({ path: armors.value[0].list[0].url });
-        }
-      };
-
-      onBeforeMount(async () => {
-        await initPages();
-      });
-
-      return {
-        isMobile,
-        fullscreen,
-        armors,
-        filter,
-        showRightSide: computed(() => route.name === 'armorDetail'),
-        initPages,
-        onSearch
-      };
-    }
+  const filter = useFilter({
+    dbName: ArmorsFilterDefaults.dbName,
+    url: ArmorsFilterDefaults.url
   });
+
+  const {
+    initPages,
+    items: armors
+  } = usePagination({
+    url: '/armors',
+    limit: -1,
+    search: filter.search,
+    order: [
+      {
+        field: 'AC',
+        direction: 'asc'
+      }
+    ]
+  });
+
+  const onSearch = async () => {
+    await initPages();
+
+    if (armors.value.length === 1 && !isMobile.value) {
+      await router.push({ path: armors.value[0].url });
+    }
+  };
+
+  const getArmorGroup = ({ type }: AnyObject & {type: AnyObject}) => ({
+    url: type.name,
+    name: type.name,
+    order: type.order
+  });
+
+  onBeforeMount(async () => {
+    await initPages();
+  });
+
+  const showRightSide = computed(() => route.name === 'armorDetail');
 </script>

--- a/src/views/Inventory/Armors/ArmorsView.vue
+++ b/src/views/Inventory/Armors/ArmorsView.vue
@@ -9,7 +9,7 @@
     <virtual-grouped-list
       :grid="{ flat: showRightSide }"
       :get-group="getArmorGroup"
-      :list="{ items: armors, keyField: 'url' }"
+      :list="{ items: armors, keyField: DEFAULT_ENTITY_KEY_FIELD }"
     >
       <template #default="{ item: armor }">
         <armor-link
@@ -33,6 +33,7 @@
   import { ArmorsFilterDefaults } from '@/types/Inventory/Armors.types';
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import type { AnyObject } from "@/types/Shared/Utility.types";
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Inventory/Armors/ArmorsView.vue
+++ b/src/views/Inventory/Armors/ArmorsView.vue
@@ -9,7 +9,7 @@
     <virtual-grouped-list
       :grid="{ flat: showRightSide }"
       :get-group="getArmorGroup"
-      :list="{ items: armors, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :list="getListProps({ items: armors })"
     >
       <template #default="{ item: armor }">
         <armor-link
@@ -33,7 +33,7 @@
   import { ArmorsFilterDefaults } from '@/types/Inventory/Armors.types';
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import type { AnyObject } from "@/types/Shared/Utility.types";
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Inventory/Items/ItemDetail.vue
+++ b/src/views/Inventory/Items/ItemDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="item-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="item?.name?.eng || ''"

--- a/src/views/Inventory/Items/ItemsView.vue
+++ b/src/views/Inventory/Items/ItemsView.vue
@@ -8,8 +8,8 @@
     @list-end="nextPage"
   >
     <virtual-grid-list
+      :list="{ items, keyField: DEFAULT_ENTITY_KEY_FIELD }"
       :flat="showRightSide"
-      :list="{ items, keyField: 'url' }"
     >
       <template #default="{ item }">
         <item-link
@@ -32,6 +32,7 @@
   import { useUIStore } from '@/store/UI/UIStore';
   import { ItemsFilterDefaults } from '@/types/Inventory/Items.types';
   import ItemLink from '@/views/Inventory/Items/ItemLink.vue';
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Inventory/Items/ItemsView.vue
+++ b/src/views/Inventory/Items/ItemsView.vue
@@ -78,10 +78,6 @@
   onBeforeMount(async () => {
     await filter.initFilter();
     await initPages();
-
-    if (!isMobile.value && items.value.length && route.name === 'items') {
-      await router.push({ path: items.value[0].url });
-    }
   });
 
   const showRightSide = computed(() => route.name === 'itemDetail');

--- a/src/views/Inventory/Items/ItemsView.vue
+++ b/src/views/Inventory/Items/ItemsView.vue
@@ -7,9 +7,10 @@
     @update="initPages"
     @list-end="nextPage"
   >
-    <virtual-grid-list
+    <virtual-grouped-list
       :list="{ items, keyField: DEFAULT_ENTITY_KEY_FIELD }"
-      :flat="showRightSide"
+      :get-group="getGroupByFirstLetter"
+      :grid="{ flat: showRightSide }"
     >
       <template #default="{ item }">
         <item-link
@@ -17,7 +18,7 @@
           :to="{ path: item.url }"
         />
       </template>
-    </virtual-grid-list>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
@@ -28,11 +29,12 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import ContentLayout from '@/components/content/ContentLayout.vue';
-  import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
   import { useUIStore } from '@/store/UI/UIStore';
   import { ItemsFilterDefaults } from '@/types/Inventory/Items.types';
   import ItemLink from '@/views/Inventory/Items/ItemLink.vue';
   import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
+  import { getGroupByFirstLetter } from "@/common/helpers/list";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Inventory/Items/ItemsView.vue
+++ b/src/views/Inventory/Items/ItemsView.vue
@@ -32,7 +32,7 @@
   import { useUIStore } from '@/store/UI/UIStore';
   import { ItemsFilterDefaults } from '@/types/Inventory/Items.types';
   import ItemLink from '@/views/Inventory/Items/ItemLink.vue';
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import { getGroupByFirstLetter } from "@/common/helpers/list";
 
@@ -56,7 +56,7 @@
     items
   } = usePagination({
     url: '/items',
-    limit: 120,
+    limit: DEFAULT_PAGINATION_ITEMS_LIMIT,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Inventory/Items/ItemsView.vue
+++ b/src/views/Inventory/Items/ItemsView.vue
@@ -56,7 +56,7 @@
     items
   } = usePagination({
     url: '/items',
-    limit: 70,
+    limit: 120,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Inventory/Items/ItemsView.vue
+++ b/src/views/Inventory/Items/ItemsView.vue
@@ -8,7 +8,7 @@
     @list-end="nextPage"
   >
     <virtual-grouped-list
-      :list="{ items, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :list="getListProps({ items })"
       :get-group="getGroupByFirstLetter"
       :grid="{ flat: showRightSide }"
     >
@@ -32,9 +32,10 @@
   import { useUIStore } from '@/store/UI/UIStore';
   import { ItemsFilterDefaults } from '@/types/Inventory/Items.types';
   import ItemLink from '@/views/Inventory/Items/ItemLink.vue';
-  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
+  import { DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import { getGroupByFirstLetter } from "@/common/helpers/list";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Inventory/MagicItems/MagicItemDetail.vue
+++ b/src/views/Inventory/MagicItems/MagicItemDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="magic-item-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="magicItem?.name?.eng || ''"

--- a/src/views/Inventory/MagicItems/MagicItemsView.vue
+++ b/src/views/Inventory/MagicItems/MagicItemsView.vue
@@ -8,8 +8,8 @@
     @list-end="nextPage"
   >
     <virtual-grid-list
+      :list="{ items, keyField: DEFAULT_ENTITY_KEY_FIELD }"
       :flat="showRightSide"
-      :list="{ items, keyField: 'url' }"
     >
       <template #default="{ item }">
         <magic-item-link
@@ -32,6 +32,7 @@
   import { useUIStore } from '@/store/UI/UIStore';
   import { MagicItemsFilterDefaults } from '@/types/Inventory/MagicItems.types';
   import MagicItemLink from '@/views/Inventory/MagicItems/MagicItemLink.vue';
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Inventory/MagicItems/MagicItemsView.vue
+++ b/src/views/Inventory/MagicItems/MagicItemsView.vue
@@ -33,7 +33,7 @@
   import { useUIStore } from '@/store/UI/UIStore';
   import { MagicItemsFilterDefaults } from '@/types/Inventory/MagicItems.types';
   import MagicItemLink from '@/views/Inventory/MagicItems/MagicItemLink.vue';
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import type { AnyObject } from "@/types/Shared/Utility.types";
 
@@ -57,7 +57,7 @@
     items
   } = usePagination({
     url: '/items/magic',
-    limit: 120,
+    limit: DEFAULT_PAGINATION_ITEMS_LIMIT,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Inventory/MagicItems/MagicItemsView.vue
+++ b/src/views/Inventory/MagicItems/MagicItemsView.vue
@@ -7,9 +7,10 @@
     @update="initPages"
     @list-end="nextPage"
   >
-    <virtual-grid-list
+    <virtual-grouped-list
       :list="{ items, keyField: DEFAULT_ENTITY_KEY_FIELD }"
-      :flat="showRightSide"
+      :get-group="getGroupByRarity"
+      :grid="{ flat: showRightSide }"
     >
       <template #default="{ item }">
         <magic-item-link
@@ -17,7 +18,7 @@
           :to="{ path: item.url }"
         />
       </template>
-    </virtual-grid-list>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
@@ -25,7 +26,7 @@
   import { storeToRefs } from 'pinia';
   import { computed, onBeforeMount } from 'vue';
   import { useRoute, useRouter } from 'vue-router';
-  import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import capitalize from "lodash/capitalize";
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import ContentLayout from '@/components/content/ContentLayout.vue';
@@ -33,8 +34,10 @@
   import { MagicItemsFilterDefaults } from '@/types/Inventory/MagicItems.types';
   import MagicItemLink from '@/views/Inventory/MagicItems/MagicItemLink.vue';
   import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
+  import type { AnyObject } from "@/types/Shared/Utility.types";
 
-  const route = useRoute();
+  const route = useRoute;
   const router = useRouter();
   const uiStore = useUIStore();
 
@@ -79,6 +82,11 @@
       await router.push({ path: items.value[0].url });
     }
   };
+
+  const getGroupByRarity = (item: AnyObject & {rarity: AnyObject}) => ({
+    url: item.rarity.type,
+    name: capitalize(String(item.rarity.name))
+  });
 
   onBeforeMount(async () => {
     await filter.initFilter();

--- a/src/views/Inventory/MagicItems/MagicItemsView.vue
+++ b/src/views/Inventory/MagicItems/MagicItemsView.vue
@@ -8,7 +8,7 @@
     @list-end="nextPage"
   >
     <virtual-grouped-list
-      :list="{ items, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :list="getListProps({ items })"
       :get-group="getGroupByRarity"
       :grid="{ flat: showRightSide }"
     >
@@ -33,9 +33,10 @@
   import { useUIStore } from '@/store/UI/UIStore';
   import { MagicItemsFilterDefaults } from '@/types/Inventory/MagicItems.types';
   import MagicItemLink from '@/views/Inventory/MagicItems/MagicItemLink.vue';
-  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
+  import { DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import type { AnyObject } from "@/types/Shared/Utility.types";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   const route = useRoute;
   const router = useRouter();

--- a/src/views/Inventory/MagicItems/MagicItemsView.vue
+++ b/src/views/Inventory/MagicItems/MagicItemsView.vue
@@ -82,10 +82,6 @@
   onBeforeMount(async () => {
     await filter.initFilter();
     await initPages();
-
-    if (!isMobile.value && items.value.length && route.name === 'magicItems') {
-      await router.push({ path: items.value[0].url });
-    }
   });
 
   const showRightSide = computed(() => route.name === 'magicItemDetail');

--- a/src/views/Inventory/MagicItems/MagicItemsView.vue
+++ b/src/views/Inventory/MagicItems/MagicItemsView.vue
@@ -57,7 +57,7 @@
     items
   } = usePagination({
     url: '/items/magic',
-    limit: 70,
+    limit: 120,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Inventory/Treasures/TreasuresView.vue
+++ b/src/views/Inventory/Treasures/TreasuresView.vue
@@ -49,7 +49,7 @@
     items
   } = usePagination({
     url: '/treasures',
-    limit: 70,
+    limit: 120,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Inventory/Treasures/TreasuresView.vue
+++ b/src/views/Inventory/Treasures/TreasuresView.vue
@@ -6,15 +6,16 @@
     @update="initPages"
     @list-end="nextPage"
   >
-    <virtual-grid-list
+    <virtual-grouped-list
       :list="{ items: treasures }"
+      :get-group="getGroupWithIdByFirstLetter"
     >
       <template #default="{ item: treasure }">
         <treasure-item
           :treasure="treasure"
         />
       </template>
-    </virtual-grid-list>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
@@ -27,7 +28,8 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { TreasuresFilterDefaults } from '@/types/Inventory/Treasures.types';
-  import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
+  import { getGroupWithIdByFirstLetter } from "@/common/helpers/list";
 
   const uiStore = useUIStore();
 

--- a/src/views/Inventory/Treasures/TreasuresView.vue
+++ b/src/views/Inventory/Treasures/TreasuresView.vue
@@ -30,6 +30,7 @@
   import { TreasuresFilterDefaults } from '@/types/Inventory/Treasures.types';
   import VirtualGroupedList from '@/components/list/VirtualGroupedList/VirtualGroupedList.vue';
   import { getGroupWithIdByFirstLetter } from "@/common/helpers/list";
+  import { DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
 
   const uiStore = useUIStore();
 
@@ -49,7 +50,7 @@
     items
   } = usePagination({
     url: '/treasures',
-    limit: 120,
+    limit: DEFAULT_PAGINATION_ITEMS_LIMIT,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Inventory/Weapons/WeaponDetail.vue
+++ b/src/views/Inventory/Weapons/WeaponDetail.vue
@@ -2,7 +2,6 @@
   <content-detail>
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :fullscreen="!isMobile"
         :subtitle="weapon?.name?.eng"
         :title="weapon?.name?.rus"

--- a/src/views/Inventory/Weapons/WeaponsView.vue
+++ b/src/views/Inventory/Weapons/WeaponsView.vue
@@ -6,133 +6,89 @@
     @search="onSearch"
     @update="initPages"
   >
-    <div
-      v-for="(group, groupKey) in weapons"
-      :key="groupKey"
-      class="weapons-group"
+    <virtual-grouped-list
+      :grid="{ flat: showRightSide }"
+      :get-group="getWeaponGroup"
+      :list="{
+        keyField: 'url',
+        items: weapons,
+      }"
     >
-      <div class="weapons-group__name">
-        {{ group.name }}
-      </div>
-
-      <div class="weapons-group__list">
+      <template #default="{ item: weapon }">
         <weapon-link
-          v-for="weapon in group.list"
-          :key="weapon.url"
           :to="{ path: weapon.url }"
           :weapon="weapon"
         />
-      </div>
-    </div>
+      </template>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
-<script lang="ts">
-  import {
-    computed, defineComponent, onBeforeMount
-  } from 'vue';
-  import sortBy from 'lodash/sortBy';
+<script lang="ts" setup>
+  import { computed, onBeforeMount } from 'vue';
   import { storeToRefs } from 'pinia';
   import { useRoute, useRouter } from 'vue-router';
   import ContentLayout from '@/components/content/ContentLayout.vue';
-  import WeaponLink from '@/views/Inventory/Weapons/WeaponLink.vue';
   import { useUIStore } from '@/store/UI/UIStore';
   import { useFilter } from '@/common/composition/useFilter';
   import { WeaponsFilterDefaults } from '@/types/Inventory/Weapons.types';
   import { usePagination } from '@/common/composition/usePagination';
+  import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
+  import type { AnyObject } from "@/types/Shared/Utility.types";
+  import WeaponLink from "@/views/Inventory/Weapons/WeaponLink.vue";
 
-  export default defineComponent({
-    components: {
-      WeaponLink,
-      ContentLayout
+  const route = useRoute();
+  const router = useRouter();
+  const uiStore = useUIStore();
+
+  const {
+    isMobile,
+    fullscreen
+  } = storeToRefs(uiStore);
+
+  const filter = useFilter({
+    dbName: WeaponsFilterDefaults.dbName,
+    url: WeaponsFilterDefaults.url
+  });
+
+  const {
+    initPages,
+    items: weapons
+  } = usePagination({
+    url: '/weapons',
+    limit: -1,
+    filter: {
+      isCustomized: filter.isCustomized,
+      value: filter.queryParams
     },
-    setup() {
-      const route = useRoute();
-      const router = useRouter();
-      const uiStore = useUIStore();
+    search: filter.search,
+    order: [
+      {
+        field: 'name',
+        direction: 'asc'
+      }
+    ]
+  });
 
-      const {
-        isMobile,
-        fullscreen
-      } = storeToRefs(uiStore);
+  const onSearch = async () => {
+    await initPages();
 
-      const filter = useFilter({
-        dbName: WeaponsFilterDefaults.dbName,
-        url: WeaponsFilterDefaults.url
-      });
-
-      const {
-        initPages,
-        items
-      } = usePagination({
-        url: '/weapons',
-        limit: -1,
-        filter: {
-          isCustomized: filter.isCustomized,
-          value: filter.queryParams
-        },
-        search: filter.search,
-        order: [
-          {
-            field: 'name',
-            direction: 'asc'
-          }
-        ]
-      });
-
-      // TODO: Доделать типизацию
-      const weapons = computed(() => {
-        const list: any = [];
-        const types: any = [];
-
-        if (!items.value) {
-          return list;
-        }
-
-        for (const armor of items.value) {
-          if (types.find((obj: any) => obj.name === armor.type.name)) {
-            continue;
-          }
-
-          types.push(armor.type);
-        }
-
-        for (const type of sortBy(types, [o => o.order])) {
-          list.push({
-            name: type.name,
-            list: items.value.filter(armor => armor.type.name === type.name)
-          });
-        }
-
-        return list;
-      });
-
-      const onSearch = async () => {
-        await initPages();
-
-        if (weapons.value.length === 1 && !isMobile.value) {
-          await router.push({ path: weapons.value[0].list[0].url });
-        }
-      };
-
-      onBeforeMount(async () => {
-        await filter.initFilter();
-        await initPages();
-      });
-
-      return {
-        isMobile,
-        fullscreen,
-        weapons,
-        filter,
-        showRightSide: computed(() => route.name === 'weaponDetail'),
-        initPages,
-        onSearch
-      };
+    if (weapons.value.length === 1 && !isMobile.value) {
+      await router.push({ path: weapons.value[0].url });
     }
+  };
+
+  onBeforeMount(async () => {
+    await filter.initFilter();
+    await initPages();
+  });
+
+  const showRightSide = computed(() => route.name === 'weaponDetail');
+
+  /* TODO: Добавить тип доспеха */
+  const getWeaponGroup = ({ type }: AnyObject & {type: AnyObject}) => ({
+    url: type.name,
+    name: type.name,
+    order: type.order
   });
 </script>
-
-<style lang="scss" scoped>
-
-</style>

--- a/src/views/Inventory/Weapons/WeaponsView.vue
+++ b/src/views/Inventory/Weapons/WeaponsView.vue
@@ -118,10 +118,6 @@
       onBeforeMount(async () => {
         await filter.initFilter();
         await initPages();
-
-        if (!isMobile.value && weapons.value.length && route.name === 'weapons') {
-          await router.push({ path: weapons.value[0].list[0].url });
-        }
       });
 
       return {

--- a/src/views/Inventory/Weapons/WeaponsView.vue
+++ b/src/views/Inventory/Weapons/WeaponsView.vue
@@ -9,10 +9,9 @@
     <virtual-grouped-list
       :grid="{ flat: showRightSide }"
       :get-group="getWeaponGroup"
-      :list="{
-        keyField: DEFAULT_ENTITY_KEY_FIELD,
+      :list="getListProps({
         items: weapons,
-      }"
+      })"
     >
       <template #default="{ item: weapon }">
         <weapon-link
@@ -36,7 +35,7 @@
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import type { AnyObject } from "@/types/Shared/Utility.types";
   import WeaponLink from "@/views/Inventory/Weapons/WeaponLink.vue";
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   const route = useRoute();
   const router = useRouter();
@@ -87,7 +86,7 @@
   const showRightSide = computed(() => route.name === 'weaponDetail');
 
   /* TODO: Добавить тип доспеха */
-  const getWeaponGroup = ({ type }: AnyObject & {type: AnyObject}) => ({
+  const getWeaponGroup = ({ type }: AnyObject & { type: AnyObject }) => ({
     url: type.name,
     name: type.name,
     order: type.order

--- a/src/views/Inventory/Weapons/WeaponsView.vue
+++ b/src/views/Inventory/Weapons/WeaponsView.vue
@@ -10,7 +10,7 @@
       :grid="{ flat: showRightSide }"
       :get-group="getWeaponGroup"
       :list="{
-        keyField: 'url',
+        keyField: DEFAULT_ENTITY_KEY_FIELD,
         items: weapons,
       }"
     >
@@ -36,6 +36,7 @@
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import type { AnyObject } from "@/types/Shared/Utility.types";
   import WeaponLink from "@/views/Inventory/Weapons/WeaponLink.vue";
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Tools/TraderView.vue
+++ b/src/views/Tools/TraderView.vue
@@ -84,7 +84,6 @@
       <content-detail>
         <template #fixed>
           <section-header
-            :close-on-desktop="fullscreen"
             :fullscreen="!isMobile"
             :subtitle="selected.item?.name.eng || 'On sale'"
             :title="selected.item?.name.rus || 'В продаже'"

--- a/src/views/Tools/TreasuryView.vue
+++ b/src/views/Tools/TreasuryView.vue
@@ -164,7 +164,6 @@
       <content-detail>
         <template #fixed>
           <section-header
-            :close-on-desktop="fullscreen"
             :fullscreen="!isMobile"
             :subtitle="selected.item?.name.eng || 'In treasury'"
             :title="selected.item?.name.rus || 'В сокровищнице'"

--- a/src/views/Tools/TreasuryView.vue
+++ b/src/views/Tools/TreasuryView.vue
@@ -483,7 +483,7 @@
 
         clearSelected();
 
-        result.value = res.data;
+        result.value = res.data as never;
       })
       .catch(err => {
         errorHandler(err);

--- a/src/views/Wiki/Books/BookDetail.vue
+++ b/src/views/Wiki/Books/BookDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="book-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="book?.name?.eng || ''"

--- a/src/views/Wiki/Books/BooksView.vue
+++ b/src/views/Wiki/Books/BooksView.vue
@@ -68,7 +68,7 @@
         items
       } = usePagination({
         url: '/books',
-        limit: 70,
+        limit: 120,
         search: filter.search,
         order: [
           {

--- a/src/views/Wiki/Books/BooksView.vue
+++ b/src/views/Wiki/Books/BooksView.vue
@@ -119,10 +119,6 @@
 
       onBeforeMount(async () => {
         await initPages();
-
-        if (!isMobile.value && books.value.length && route.name === 'books') {
-          await router.push({ path: books.value[0].list[0].url });
-        }
       });
 
       return {

--- a/src/views/Wiki/Books/BooksView.vue
+++ b/src/views/Wiki/Books/BooksView.vue
@@ -41,6 +41,7 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { BooksFilterDefaults } from '@/types/Wiki/Books.types';
+  import { DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
 
   export default defineComponent({
     components: {
@@ -68,7 +69,7 @@
         items
       } = usePagination({
         url: '/books',
-        limit: 120,
+        limit: DEFAULT_PAGINATION_ITEMS_LIMIT,
         search: filter.search,
         order: [
           {

--- a/src/views/Wiki/Gods/GodDetail.vue
+++ b/src/views/Wiki/Gods/GodDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="god-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="god?.name?.eng || ''"

--- a/src/views/Wiki/Gods/GodsView.vue
+++ b/src/views/Wiki/Gods/GodsView.vue
@@ -81,10 +81,6 @@
   onBeforeMount(async () => {
     await filter.initFilter();
     await initPages();
-
-    if (!isMobile.value && gods.value.length && route.name === 'gods') {
-      await router.push({ path: gods.value[0].url });
-    }
   });
 
   const showRightSide = computed(() => route.name === 'godDetail');

--- a/src/views/Wiki/Gods/GodsView.vue
+++ b/src/views/Wiki/Gods/GodsView.vue
@@ -61,7 +61,7 @@
     items: gods
   } = usePagination({
     url: '/gods',
-    limit: 70,
+    limit: 125,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Wiki/Gods/GodsView.vue
+++ b/src/views/Wiki/Gods/GodsView.vue
@@ -7,12 +7,14 @@
     @update="initPages"
     @list-end="nextPage"
   >
-    <virtual-grid-list
+    <virtual-grouped-list
       :flat="showRightSide"
       :list="{
         items: gods,
         keyField: DEFAULT_ENTITY_KEY_FIELD,
       }"
+      :get-group="getGroupByAlignment"
+      :grid="{ flat: showRightSide }"
     >
       <template #default="{ item: god }">
         <god-link
@@ -20,7 +22,7 @@
           :to="{ path: god.url }"
         />
       </template>
-    </virtual-grid-list>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
@@ -28,14 +30,16 @@
   import { computed, onBeforeMount } from 'vue';
   import { storeToRefs } from 'pinia';
   import { useRoute, useRouter } from 'vue-router';
+  import capitalize from "lodash/capitalize";
   import ContentLayout from '@/components/content/ContentLayout.vue';
   import GodLink from '@/views/Wiki/Gods/GodLink.vue';
   import { useUIStore } from '@/store/UI/UIStore';
   import { GodsFilterDefaults } from '@/types/Wiki/Gods.types';
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
-  import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
   import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
+  import type { AnyObject } from "@/types/Shared/Utility.types";
 
   const route = useRoute();
   const router = useRouter();
@@ -65,6 +69,10 @@
     search: filter.search,
     order: [
       {
+        field: 'aligment',
+        direction: 'asc'
+      },
+      {
         field: 'name',
         direction: 'asc'
       }
@@ -78,6 +86,11 @@
       await router.push({ path: gods.value[0].url });
     }
   };
+
+  const getGroupByAlignment = (god: AnyObject) => ({
+    [DEFAULT_ENTITY_KEY_FIELD]: god.alignment,
+    name: capitalize(String(god.alignment))
+  });
 
   onBeforeMount(async () => {
     await filter.initFilter();

--- a/src/views/Wiki/Gods/GodsView.vue
+++ b/src/views/Wiki/Gods/GodsView.vue
@@ -9,10 +9,7 @@
   >
     <virtual-grouped-list
       :flat="showRightSide"
-      :list="{
-        items: gods,
-        keyField: DEFAULT_ENTITY_KEY_FIELD,
-      }"
+      :list="getListProps({ items: gods })"
       :get-group="getGroupByAlignment"
       :grid="{ flat: showRightSide }"
     >
@@ -40,6 +37,7 @@
   import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import type { AnyObject } from "@/types/Shared/Utility.types";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Wiki/Gods/GodsView.vue
+++ b/src/views/Wiki/Gods/GodsView.vue
@@ -11,7 +11,7 @@
       :flat="showRightSide"
       :list="{
         items: gods,
-        keyField: 'url',
+        keyField: DEFAULT_ENTITY_KEY_FIELD,
       }"
     >
       <template #default="{ item: god }">
@@ -35,6 +35,7 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Wiki/Rules/RuleDetail.vue
+++ b/src/views/Wiki/Rules/RuleDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="rule-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="rule?.name?.eng || ''"

--- a/src/views/Wiki/Rules/RulesView.vue
+++ b/src/views/Wiki/Rules/RulesView.vue
@@ -32,7 +32,7 @@
   import { usePagination } from '@/common/composition/usePagination';
   import { RulesFilterDefaults } from '@/types/Wiki/Rules.types';
   import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();
@@ -54,7 +54,7 @@
     items: rules
   } = usePagination({
     url: '/rules',
-    limit: 120,
+    limit: DEFAULT_PAGINATION_ITEMS_LIMIT,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Wiki/Rules/RulesView.vue
+++ b/src/views/Wiki/Rules/RulesView.vue
@@ -8,8 +8,8 @@
     @list-end="nextPage"
   >
     <virtual-grid-list
+      :list="{ items: rules, keyField: DEFAULT_ENTITY_KEY_FIELD }"
       :flat="showRightSide"
-      :list="{ items: rules, keyField: 'url' }"
     >
       <template #default="{ item: rule }">
         <rule-link
@@ -32,6 +32,7 @@
   import { usePagination } from '@/common/composition/usePagination';
   import { RulesFilterDefaults } from '@/types/Wiki/Rules.types';
   import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Wiki/Rules/RulesView.vue
+++ b/src/views/Wiki/Rules/RulesView.vue
@@ -78,10 +78,6 @@
   onBeforeMount(async () => {
     await filter.initFilter();
     await initPages();
-
-    if (!isMobile.value && rules.value.length && route.name === 'rules') {
-      await router.push({ path: rules.value[0].url });
-    }
   });
 
   const showRightSide = computed(() => route.name === 'ruleDetail');

--- a/src/views/Wiki/Rules/RulesView.vue
+++ b/src/views/Wiki/Rules/RulesView.vue
@@ -54,7 +54,7 @@
     items: rules
   } = usePagination({
     url: '/rules',
-    limit: 70,
+    limit: 120,
     filter: {
       isCustomized: filter.isCustomized,
       value: filter.queryParams

--- a/src/views/Wiki/Rules/RulesView.vue
+++ b/src/views/Wiki/Rules/RulesView.vue
@@ -8,7 +8,7 @@
     @list-end="nextPage"
   >
     <virtual-grid-list
-      :list="{ items: rules, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :list="getListProps({ items: rules })"
       :flat="showRightSide"
     >
       <template #default="{ item: rule }">
@@ -32,7 +32,8 @@
   import { usePagination } from '@/common/composition/usePagination';
   import { RulesFilterDefaults } from '@/types/Wiki/Rules.types';
   import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
-  import { DEFAULT_ENTITY_KEY_FIELD, DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
+  import { DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Workshop/Bestiary/BestiaryView.vue
+++ b/src/views/Workshop/Bestiary/BestiaryView.vue
@@ -8,8 +8,8 @@
     @list-end="nextPage"
   >
     <virtual-grid-list
+      :list="{ items: bestiary, keyField: DEFAULT_ENTITY_KEY_FIELD }"
       :flat="showRightSide"
-      :list="{ items: bestiary, keyField: 'url' }"
     >
       <template #default="{ item: creature }">
         <creature-link
@@ -32,6 +32,7 @@
   import { usePagination } from '@/common/composition/usePagination';
   import { BestiaryFilterDefaults } from '@/types/Workshop/Bestiary.types';
   import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
+  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Workshop/Bestiary/BestiaryView.vue
+++ b/src/views/Workshop/Bestiary/BestiaryView.vue
@@ -8,7 +8,7 @@
     @list-end="nextPage"
   >
     <virtual-grouped-list
-      :list="{ items: bestiary, keyField: DEFAULT_ENTITY_KEY_FIELD }"
+      :list="getListProps({ items: bestiary })"
       :get-group="getGroupByChallengeRating"
       :grid="{ flat: showRightSide }"
     >
@@ -32,9 +32,9 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { BestiaryFilterDefaults } from '@/types/Workshop/Bestiary.types';
-  import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
   import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
   import type { AnyObject } from "@/types/Shared/Utility.types";
+  import { getListProps } from "@/components/list/VirtualList/helpers";
 
   const route = useRoute();
   const router = useRouter();

--- a/src/views/Workshop/Bestiary/BestiaryView.vue
+++ b/src/views/Workshop/Bestiary/BestiaryView.vue
@@ -7,9 +7,10 @@
     @update="initPages"
     @list-end="nextPage"
   >
-    <virtual-grid-list
+    <virtual-grouped-list
       :list="{ items: bestiary, keyField: DEFAULT_ENTITY_KEY_FIELD }"
-      :flat="showRightSide"
+      :get-group="getGroupByChallengeRating"
+      :grid="{ flat: showRightSide }"
     >
       <template #default="{ item: creature }">
         <creature-link
@@ -17,7 +18,7 @@
           :to="{ path: creature.url }"
         />
       </template>
-    </virtual-grid-list>
+    </virtual-grouped-list>
   </content-layout>
 </template>
 
@@ -31,8 +32,9 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { BestiaryFilterDefaults } from '@/types/Workshop/Bestiary.types';
-  import VirtualGridList from '@/components/list/VirtualGridList/VirtualGridList.vue';
   import { DEFAULT_ENTITY_KEY_FIELD } from "@/common/const";
+  import VirtualGroupedList from "@/components/list/VirtualGroupedList/VirtualGroupedList.vue";
+  import type { AnyObject } from "@/types/Shared/Utility.types";
 
   const route = useRoute();
   const router = useRouter();
@@ -74,6 +76,11 @@
       await router.push({ path: bestiary.value[0].url });
     }
   };
+
+  const getGroupByChallengeRating = (item: AnyObject) => ({
+    name: item.challengeRating,
+    url: item.challengeRating
+  });
 
   onBeforeMount(async () => {
     await filter.initFilter();

--- a/src/views/Workshop/Bestiary/BestiaryView.vue
+++ b/src/views/Workshop/Bestiary/BestiaryView.vue
@@ -78,10 +78,6 @@
     await filter.initFilter();
 
     await initPages();
-
-    if (!isMobile.value && bestiary.value.length && route.name === 'bestiary') {
-      await router.push({ path: bestiary.value[0].url });
-    }
   });
 
   const showRightSide = computed(() => route.name === 'creatureDetail');

--- a/src/views/Workshop/Bestiary/CreatureDetail.vue
+++ b/src/views/Workshop/Bestiary/CreatureDetail.vue
@@ -2,7 +2,6 @@
   <content-detail class="creature-detail">
     <template #fixed>
       <section-header
-        :close-on-desktop="fullscreen"
         :copy="!error && !loading"
         :fullscreen="!isMobile"
         :subtitle="creature?.name?.eng || ''"

--- a/src/views/Workshop/Screens/ScreenDetail.vue
+++ b/src/views/Workshop/Screens/ScreenDetail.vue
@@ -7,7 +7,6 @@
         :subtitle="screen?.name?.eng || ''"
         :title="screen?.name?.rus || ''"
         bookmark
-        close-on-desktop
         @close="close"
       />
     </template>

--- a/src/views/Workshop/Screens/ScreensView.vue
+++ b/src/views/Workshop/Screens/ScreensView.vue
@@ -39,6 +39,7 @@
   import { useFilter } from '@/common/composition/useFilter';
   import { usePagination } from '@/common/composition/usePagination';
   import { ScreensFilterDefaults } from '@/types/Workshop/Screens.types';
+  import { DEFAULT_PAGINATION_ITEMS_LIMIT } from "@/common/const";
 
   export default defineComponent({
     components: {
@@ -65,7 +66,7 @@
         items: screens
       } = usePagination({
         url: '/screens',
-        limit: 120,
+        limit: DEFAULT_PAGINATION_ITEMS_LIMIT,
         filter: {
           isCustomized: filter.isCustomized,
           value: filter.queryParams

--- a/src/views/Workshop/Screens/ScreensView.vue
+++ b/src/views/Workshop/Screens/ScreensView.vue
@@ -65,7 +65,7 @@
         items: screens
       } = usePagination({
         url: '/screens',
-        limit: 70,
+        limit: 120,
         filter: {
           isCustomized: filter.isCustomized,
           value: filter.queryParams


### PR DESCRIPTION
1. При открытие любого раздела, перестать выбирать первый элемент в списке.
2. Добавить возможность закрыть "детальник" даже когда он занимает половину (по аналогии с ширмой).
3. Везде уменьшить количество столбцов до 3 шт.
4. Разделители в заклинаниях сделать одним стилем как и в "Оружие" (что бы если что менять только стиль один надо было)
5. Добавить разделитель в:
а) Черты, Особенности классов, Предыстории, Снаряжение, Драгоценности - по алфавиту
б) Магические предметы - по редкости предмета
в) Бестиарий - по опасности монстра
г) Боги - мировоззрение 
6. Магические предметы - если открыть раздел без детальника, перестает работать погрузка списка, после буквы Б
7. Доспехи и Оружие, так-же сделать в несколько колонок