### PR TITLE
fix: text shown badly in light mode

### DIFF
--- a/src/pages/Inventory/MagicItems/MagicItemLink.vue
+++ b/src/pages/Inventory/MagicItems/MagicItemLink.vue
@@ -198,7 +198,8 @@
         &__rating,
         &__type,
         &__count,
-        &__price {
+        &__price,
+        &__customization {
           color: var(--text-btn-color);
         }
       }


### PR DESCRIPTION
https://ttg-club.atlassian.net/browse/TTG-31

<img width="1524" alt="Screenshot 2023-11-08 at 23 53 38" src="https://github.com/TTG-Club/ttg-club-frontend/assets/39695464/1949b500-695c-4aa2-a3f5-ea376c008e2f">
<img width="1460" alt="Screenshot 2023-11-08 at 23 53 28" src="https://github.com/TTG-Club/ttg-club-frontend/assets/39695464/cdfee97d-e89f-4f71-9cd7-afec07821a05">
