### PR TITLE
fix: adaptive styles for tokenator

### DIFF
--- a/src/pages/Tools/Tokenator/TokenDetails.vue
+++ b/src/pages/Tools/Tokenator/TokenDetails.vue
@@ -75,14 +75,13 @@
   .wrapper {
     border-radius: 16px;
     padding: 24px;
+    margin-top: 24px;
     background-color: var(--bg-secondary);
     border: 1px solid var(--border);
     width: fit-content;
     height: fit-content;
-    transform: translateY(-45%);
-
     @include media-min($md) {
-      margin: 0;
+      margin: 0 24px 0 0;
       transform: none;
     }
   }


### PR DESCRIPTION
Было:
<img width="1680" alt="Screenshot 2023-11-09 at 01 00 10" src="https://github.com/TTG-Club/ttg-club-frontend/assets/39695464/7d184af9-6b04-4ebe-be10-d86a734c1fab">
<img width="450" alt="Screenshot 2023-11-09 at 01 00 08" src="https://github.com/TTG-Club/ttg-club-frontend/assets/39695464/975970c0-842f-4226-9f9d-0937535fe7c3">

Стало:

<img width="1680" alt="Screenshot 2023-11-09 at 00 58 48" src="https://github.com/TTG-Club/ttg-club-frontend/assets/39695464/6dc68426-a99e-443c-8925-fd3c1aea3d5d">
<img width="1680" alt="Screenshot 2023-11-09 at 00 58 41" src="https://github.com/TTG-Club/ttg-club-frontend/assets/39695464/b5d7e519-a06c-4ff4-919f-08ed20b2832d">
