### PR TITLE
fix(reset-password): починить проверку токена и показ ошибок сброса пароля

### DIFF
--- a/src/features/account/ChangePasswordView.vue
+++ b/src/features/account/ChangePasswordView.vue
@@ -5,6 +5,7 @@
   import { ToastEventBus } from '@/shared/config';
   import { ALLOWED_SPECIAL_CHARACTERS } from '@/shared/const';
   import { useUserStore } from '@/shared/stores/UserStore';
+  import { getApiErrorMessage } from '@/shared/utils/apiError';
   import {
     ruleEmail,
     rulePassword,
@@ -148,7 +149,7 @@
 
       success.value = true;
     } catch (err) {
-      toast.error('Неизвестная ошибка');
+      toast.error(getApiErrorMessage(err));
     } finally {
       inProgress.value = false;
     }

--- a/src/pages/user/reset-password/ResetPasswordView.vue
+++ b/src/pages/user/reset-password/ResetPasswordView.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { httpClient } from '@/shared/api';
   import { useUserStore } from '@/shared/stores/UserStore';
+  import { getApiErrorMessage } from '@/shared/utils/apiError';
 
   import ChangePasswordView from '@/features/account/ChangePasswordView.vue';
 
@@ -33,29 +34,29 @@
         }
 
         try {
-          const resp = await httpClient.get<ITokenValidation>({
-            url: '/auth/password/reset-token/validate',
+          // auth-service отвечает 204 без тела, если токен валиден,
+          // и 400 с полем message — если нет.
+          await httpClient.get({
+            url: '/account/password/reset-token/validate',
             payload: {
               token: route.query.token,
             },
+            version: 'auth',
           });
 
-          if (resp.status !== 200) {
-            tokenValidation.value = {
-              correct: false,
-              message: 'Неизвестная ошибка',
-            };
-
-            return Promise.resolve();
-          }
-
-          tokenValidation.value = resp.data;
+          tokenValidation.value = {
+            correct: true,
+            message: '',
+          };
 
           return Promise.resolve();
         } catch (err) {
           tokenValidation.value = {
             correct: false,
-            message: 'Неизвестная ошибка',
+            message: getApiErrorMessage(
+              err,
+              'Не удалось проверить ссылку для сброса пароля',
+            ),
           };
 
           return Promise.resolve();


### PR DESCRIPTION
## Проблема

Пользователи жаловались на баннер «Неизвестная ошибка» при восстановлении пароля — на старом сайте флоу был сломан полностью.

Страница `/reset-password` при открытии проверяла токен запросом `GET /api/v1/auth/password/reset-token/validate` (дефолтная версия API `v1`), но такого эндпоинта в монолите нет — есть только `/api/v1/auth/token/validate`. Запрос всегда падал с 404 → `catch` ставил `{correct: false, message: 'Неизвестная ошибка'}` → баннер показывался сразу при заходе по ссылке из письма, а сабмит формы блокировался. При этом сами reset-request/reset-confirm уже ходят в новый auth-service.

## Что сделано

- Валидация токена переведена на auth-service: `GET /api/account/password/reset-token/validate` с `version: 'auth'`. Новый контракт: 204 без тела = токен валиден, 400 с полем `message` = нет (старый ждал 200 с `{correct, message}`).
- В `ChangePasswordView` тост ошибки сброса показывает сообщение сервера через существующий хелпер `getApiErrorMessage` вместо безусловной «Неизвестной ошибки».

Парный PR в auth-service (400 с человеческими сообщениями вместо 500 для невалидного/использованного/истёкшего токена): TTG-Club/auth-service#11. Без него сообщения будут «Внутренняя ошибка сервера», с ним — «Срок действия ссылки для сброса пароля истёк — запросите новую» и т.п.

## Проверка

`npm run type-check` проходит; eslint/prettier отработали в pre-commit хуке.

🤖 Generated with [Claude Code](https://claude.com/claude-code)