### PR TITLE
feat(workshop): html-редактор для полей описаний

### DIFF
--- a/src/pages/workshop/armors/ArmorEditor.vue
+++ b/src/pages/workshop/armors/ArmorEditor.vue
@@ -3,6 +3,7 @@
   import { useBookSources } from '@/shared/composable/useBookSources';
   import { useDiscreteApi } from '@/shared/composable/useDiscreteApi';
   import type { ArmorItem, ArmorSave } from '@/shared/types/inventory/Armors';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -175,14 +176,14 @@
       </n-checkbox>
     </div>
 
-    <label class="armor-editor__field armor-editor__field--wide">
+    <div class="armor-editor__field armor-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
-        rows="10"
+        :rows="10"
       />
-    </label>
+    </div>
 
     <label class="armor-editor__field armor-editor__field--wide">
       <span>Источник</span>

--- a/src/pages/workshop/backgrounds/BackgroundEditor.vue
+++ b/src/pages/workshop/backgrounds/BackgroundEditor.vue
@@ -6,6 +6,7 @@
     BackgroundItem,
     BackgroundSave,
   } from '@/shared/types/character/Backgrounds';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -216,15 +217,15 @@
       />
     </label>
 
-    <label class="background-editor__field background-editor__field--wide">
+    <div class="background-editor__field background-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
+        :rows="12"
         required
-        rows="12"
       />
-    </label>
+    </div>
 
     <label class="background-editor__field background-editor__field--wide">
       <span>Название умения предыстории</span>
@@ -235,23 +236,23 @@
       />
     </label>
 
-    <label class="background-editor__field background-editor__field--wide">
+    <div class="background-editor__field background-editor__field--wide">
       <span>Описание умения предыстории</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.skillDescription"
-        rows="8"
+        :rows="8"
       />
-    </label>
+    </div>
 
-    <label class="background-editor__field background-editor__field--wide">
+    <div class="background-editor__field background-editor__field--wide">
       <span>Персонализация</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.personalization"
-        rows="8"
+        :rows="8"
       />
-    </label>
+    </div>
 
     <label class="background-editor__field background-editor__field--wide">
       <span>Источник</span>

--- a/src/pages/workshop/bestiary/CreatureEditor.vue
+++ b/src/pages/workshop/bestiary/CreatureEditor.vue
@@ -8,6 +8,7 @@
     ICreatureSaveDescription,
     ICreatureSaveNameValue,
   } from '@/shared/types/workshop/Bestiary';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -1071,14 +1072,14 @@
       </label>
     </div>
 
-    <label class="creature-editor__field creature-editor__field--wide">
+    <div class="creature-editor__field creature-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
-        rows="8"
+        :rows="8"
       />
-    </label>
+    </div>
 
     <section
       v-for="section in textBlockSections"
@@ -1102,8 +1103,6 @@
         class="creature-editor__text-block"
       >
         <div class="creature-editor__text-block_header">
-          <strong>{{ section.title }} #{{ blockIndex + 1 }}</strong>
-
           <button
             type="button"
             @click="removeTextBlock(section.key, blockIndex)"
@@ -1138,14 +1137,14 @@
           />
         </label>
 
-        <label class="creature-editor__field creature-editor__field--wide">
+        <div class="creature-editor__field creature-editor__field--wide">
           <span>Описание</span>
 
-          <textarea
+          <ui-html-editor
             v-model="block.description"
-            rows="6"
+            :rows="6"
           />
-        </label>
+        </div>
 
         <n-checkbox v-model:checked="block.markdown">
           Используется markdown
@@ -1169,23 +1168,23 @@
       />
     </label>
 
-    <label class="creature-editor__field creature-editor__field--wide">
+    <div class="creature-editor__field creature-editor__field--wide">
       <span>Свободный текст реакций</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.reaction"
-        rows="4"
+        :rows="4"
       />
-    </label>
+    </div>
 
-    <label class="creature-editor__field creature-editor__field--wide">
+    <div class="creature-editor__field creature-editor__field--wide">
       <span>Описание легендарных действий</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.legendaryDescription"
-        rows="4"
+        :rows="4"
       />
-    </label>
+    </div>
 
     <label class="creature-editor__field creature-editor__field--wide">
       <span>Легендарные действия</span>
@@ -1321,7 +1320,7 @@
         grid-column: 1 / -1;
         gap: 12px;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-end;
       }
 
       &_warning {

--- a/src/pages/workshop/classes/ArchetypeEditView.vue
+++ b/src/pages/workshop/classes/ArchetypeEditView.vue
@@ -5,6 +5,7 @@
     ClassSpellcasterType,
     ClassTrait,
   } from '@/shared/types/character/Classes';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   import PageLayout from '@/layouts/PageLayout.vue';
@@ -123,15 +124,15 @@
           required
       /></label>
 
-      <label class="wide"
-        ><span>Описание</span>
+      <div class="field wide">
+        <span>Описание</span>
 
-        <textarea
+        <ui-html-editor
           v-model="item.description"
-          rows="8"
+          :rows="8"
           required
         />
-      </label>
+      </div>
 
       <section class="wide">
         <div class="heading">
@@ -179,14 +180,14 @@
             Удалить
           </button>
 
-          <label class="wide"
-            ><span>Описание</span>
+          <div class="field wide">
+            <span>Описание</span>
 
-            <textarea
+            <ui-html-editor
               v-model="trait.description"
-              rows="5"
+              :rows="5"
             />
-          </label>
+          </div>
         </div>
       </section>
 
@@ -217,7 +218,8 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 16px;
   }
-  label {
+  label,
+  .field {
     display: flex;
     flex-direction: column;
     gap: 6px;

--- a/src/pages/workshop/classes/ClassEditor.vue
+++ b/src/pages/workshop/classes/ClassEditor.vue
@@ -11,6 +11,7 @@
     ClassTrait,
     TClassItem,
   } from '@/shared/types/character/Classes';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -389,51 +390,51 @@
       <span>Напарник</span>
     </label>
 
-    <label class="class-editor__field class-editor__field--wide">
+    <div class="class-editor__field class-editor__field--wide">
       <span>Доспехи</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.armor"
-        rows="3"
+        :rows="3"
       />
-    </label>
+    </div>
 
-    <label class="class-editor__field class-editor__field--wide">
+    <div class="class-editor__field class-editor__field--wide">
       <span>Оружие</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.weapon"
-        rows="3"
+        :rows="3"
       />
-    </label>
+    </div>
 
-    <label class="class-editor__field class-editor__field--wide">
+    <div class="class-editor__field class-editor__field--wide">
       <span>Инструменты</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.tools"
-        rows="3"
+        :rows="3"
       />
-    </label>
+    </div>
 
-    <label class="class-editor__field class-editor__field--wide">
+    <div class="class-editor__field class-editor__field--wide">
       <span>Снаряжение</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.equipment"
-        rows="6"
+        :rows="6"
       />
-    </label>
+    </div>
 
-    <label class="class-editor__field class-editor__field--wide">
+    <div class="class-editor__field class-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
+        :rows="12"
         required
-        rows="12"
       />
-    </label>
+    </div>
 
     <section class="class-editor__traits">
       <div class="class-editor__traits-header">
@@ -504,14 +505,14 @@
           />
         </label>
 
-        <label class="class-editor__field class-editor__field--wide">
+        <div class="class-editor__field class-editor__field--wide">
           <span>Описание</span>
 
-          <textarea
+          <ui-html-editor
             v-model="trait.description"
-            rows="8"
+            :rows="8"
           />
-        </label>
+        </div>
 
         <label class="class-editor__field class-editor__field--checkbox">
           <input

--- a/src/pages/workshop/feats/FeatEditor.vue
+++ b/src/pages/workshop/feats/FeatEditor.vue
@@ -3,6 +3,7 @@
   import { useBookSources } from '@/shared/composable/useBookSources';
   import { useDiscreteApi } from '@/shared/composable/useDiscreteApi';
   import type { FeatSave, FeatsItem } from '@/shared/types/character/Feats';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -179,15 +180,15 @@
       />
     </label>
 
-    <label class="feat-editor__field feat-editor__field--wide">
+    <div class="feat-editor__field feat-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
+        :rows="12"
         required
-        rows="12"
       />
-    </label>
+    </div>
 
     <label class="feat-editor__field feat-editor__field--wide">
       <span>Источник</span>

--- a/src/pages/workshop/items/ItemEditor.vue
+++ b/src/pages/workshop/items/ItemEditor.vue
@@ -6,6 +6,7 @@
     EquipmentItem,
     EquipmentSave,
   } from '@/shared/types/inventory/Items';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -201,14 +202,14 @@
       />
     </label>
 
-    <label class="item-editor__field item-editor__field--wide">
+    <div class="item-editor__field item-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
-        rows="10"
+        :rows="10"
       />
-    </label>
+    </div>
 
     <label class="item-editor__field item-editor__field--wide">
       <span>Источник</span>

--- a/src/pages/workshop/magic-items/MagicItemEditor.vue
+++ b/src/pages/workshop/magic-items/MagicItemEditor.vue
@@ -6,6 +6,7 @@
     MagicItemSave,
     TArtifactItem,
   } from '@/shared/types/inventory/MagicItems';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -245,15 +246,15 @@
       />
     </label>
 
-    <label class="magic-item-editor__field magic-item-editor__field--wide">
+    <div class="magic-item-editor__field magic-item-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
+        :rows="8"
         required
-        rows="8"
       />
-    </label>
+    </div>
 
     <label class="magic-item-editor__field magic-item-editor__field--wide">
       <span>Источник</span>

--- a/src/pages/workshop/options/OptionEditor.vue
+++ b/src/pages/workshop/options/OptionEditor.vue
@@ -6,6 +6,7 @@
     OptionDetail,
     OptionSave,
   } from '@/shared/types/character/Options';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -182,15 +183,15 @@
       />
     </label>
 
-    <label class="option-editor__field option-editor__field--wide">
+    <div class="option-editor__field option-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
+        :rows="12"
         required
-        rows="12"
       />
-    </label>
+    </div>
 
     <label class="option-editor__field option-editor__field--wide">
       <span>Источник</span>

--- a/src/pages/workshop/races/RaceEditor.vue
+++ b/src/pages/workshop/races/RaceEditor.vue
@@ -11,6 +11,7 @@
     TRaceFeature,
     TRaceLink,
   } from '@/shared/types/character/Races';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -518,26 +519,26 @@
           <span>Открывать по умолчанию</span>
         </label>
 
-        <label class="race-editor__field race-editor__field--wide">
+        <div class="race-editor__field race-editor__field--wide">
           <span>Описание</span>
 
-          <textarea
+          <ui-html-editor
             v-model="feature.description"
-            rows="8"
+            :rows="8"
           />
-        </label>
+        </div>
       </article>
     </section>
 
-    <label class="race-editor__field race-editor__field--wide">
+    <div class="race-editor__field race-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
+        :rows="12"
         required
-        rows="12"
       />
-    </label>
+    </div>
 
     <label class="race-editor__field race-editor__field--wide">
       <span>Источник</span>

--- a/src/pages/workshop/rules/RuleEditor.vue
+++ b/src/pages/workshop/rules/RuleEditor.vue
@@ -3,6 +3,7 @@
   import { useBookSources } from '@/shared/composable/useBookSources';
   import { useDiscreteApi } from '@/shared/composable/useDiscreteApi';
   import type { RuleDetail, RuleSave } from '@/shared/types/wiki/Rules';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = defineProps<{
@@ -123,15 +124,15 @@
       />
     </label>
 
-    <label class="rule-editor__field rule-editor__field--wide">
+    <div class="rule-editor__field rule-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
+        :rows="18"
         required
-        rows="18"
       />
-    </label>
+    </div>
 
     <div class="rule-editor__actions">
       <button

--- a/src/pages/workshop/screens/ScreenEditor.vue
+++ b/src/pages/workshop/screens/ScreenEditor.vue
@@ -6,6 +6,7 @@
     IScreenDetail,
     IScreenSave,
   } from '@/shared/types/workshop/Screens';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = defineProps<{
@@ -149,14 +150,14 @@
       </router-link>
     </div>
 
-    <label class="screen-editor__field screen-editor__field--wide">
+    <div class="screen-editor__field screen-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
-        rows="18"
+        :rows="18"
       />
-    </label>
+    </div>
 
     <div class="screen-editor__actions">
       <button

--- a/src/pages/workshop/spells/SpellEditor.vue
+++ b/src/pages/workshop/spells/SpellEditor.vue
@@ -3,6 +3,7 @@
   import { useBookSources } from '@/shared/composable/useBookSources';
   import { useDiscreteApi } from '@/shared/composable/useDiscreteApi';
   import type { TSpellItem, TSpellSave } from '@/shared/types/character/Spells';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -262,24 +263,24 @@
       />
     </label>
 
-    <label class="spell-editor__field spell-editor__field--wide">
+    <div class="spell-editor__field spell-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
+        :rows="10"
         required
-        rows="10"
       />
-    </label>
+    </div>
 
-    <label class="spell-editor__field spell-editor__field--wide">
+    <div class="spell-editor__field spell-editor__field--wide">
       <span>На больших уровнях</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.upper"
-        rows="5"
+        :rows="5"
       />
-    </label>
+    </div>
 
     <label class="spell-editor__field spell-editor__field--wide">
       <span>Источник</span>

--- a/src/pages/workshop/weapons/WeaponEditor.vue
+++ b/src/pages/workshop/weapons/WeaponEditor.vue
@@ -6,6 +6,7 @@
     WeaponItem,
     WeaponSave,
   } from '@/shared/types/inventory/Weapons';
+  import { UiHtmlEditor } from '@/shared/ui/kit/html-editor';
   import { errorHandler } from '@/shared/utils/errorHandler';
 
   const props = withDefaults(
@@ -300,23 +301,23 @@
       />
     </label>
 
-    <label class="weapon-editor__field weapon-editor__field--wide">
+    <div class="weapon-editor__field weapon-editor__field--wide">
       <span>Описание</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.description"
-        rows="8"
+        :rows="8"
       />
-    </label>
+    </div>
 
-    <label class="weapon-editor__field weapon-editor__field--wide">
+    <div class="weapon-editor__field weapon-editor__field--wide">
       <span>Особое</span>
 
-      <textarea
+      <ui-html-editor
         v-model="form.special"
-        rows="5"
+        :rows="5"
       />
-    </label>
+    </div>
 
     <label class="weapon-editor__field weapon-editor__field--wide">
       <span>Источник</span>

--- a/src/shared/ui/kit/html-editor/UiHtmlEditor.vue
+++ b/src/shared/ui/kit/html-editor/UiHtmlEditor.vue
@@ -1,0 +1,835 @@
+<script setup lang="ts">
+  import { Icon } from '@iconify/vue';
+
+  import {
+    TOKEN_CLASS,
+    createDiceToken,
+    createTokenElement,
+    editableToHtml,
+    extractFormula,
+    htmlToEditable,
+    tokenFromElement,
+  } from './helpers';
+
+  import type { DiceToken, DiceVariant, HtmlEditorMode } from './types';
+
+  const props = withDefaults(
+    defineProps<{
+      modelValue: string;
+      rows?: number;
+      placeholder?: string;
+      disabled?: boolean;
+      required?: boolean;
+    }>(),
+    {
+      rows: 18,
+      placeholder: 'Описание в формате HTML',
+      disabled: false,
+      required: false,
+    },
+  );
+
+  const emit = defineEmits<{
+    (e: 'update:modelValue', value: string): void;
+  }>();
+
+  const MODE_OPTIONS: Array<{ label: string; value: HtmlEditorMode }> = [
+    { label: 'HTML', value: 'html' },
+    { label: 'Исходный код', value: 'source' },
+  ];
+
+  const VARIANT_OPTIONS: Array<{ label: string; value: DiceVariant }> = [
+    { label: 'Обычный', value: 'dice' },
+    { label: 'Преимущество', value: 'advantage' },
+    { label: 'Помеха', value: 'disadvantage' },
+    { label: 'Спасбросок', value: 'saving-throw' },
+  ];
+
+  const LABEL_OPTIONS = [
+    'Бросок',
+    'Атака',
+    'Урон',
+    'Восстановление хитов',
+    'Проверка',
+    'Спасбросок',
+  ].map((label) => ({ label, value: label }));
+
+  const HEADING_OPTIONS = [
+    { label: 'Обычный текст', key: 'p' },
+    { label: 'Заголовок 1', key: 'h1' },
+    { label: 'Заголовок 2', key: 'h2' },
+    { label: 'Заголовок 3', key: 'h3' },
+    { label: 'Заголовок 4', key: 'h4' },
+    { label: 'Заголовок 5', key: 'h5' },
+  ];
+
+  const ALIGN_BUTTONS = [
+    {
+      command: 'justifyLeft',
+      icon: 'tabler:align-left',
+      title: 'По левому краю',
+    },
+    {
+      command: 'justifyCenter',
+      icon: 'tabler:align-center',
+      title: 'По центру',
+    },
+    {
+      command: 'justifyRight',
+      icon: 'tabler:align-right',
+      title: 'По правому краю',
+    },
+  ];
+
+  const LIST_BUTTONS = [
+    {
+      command: 'insertUnorderedList',
+      icon: 'tabler:list',
+      title: 'Маркированный список',
+    },
+    {
+      command: 'insertOrderedList',
+      icon: 'tabler:list-numbers',
+      title: 'Нумерованный список',
+    },
+  ];
+
+  const mode = ref<HtmlEditorMode>('html');
+  const editor = ref<HTMLElement | null>(null);
+
+  /**
+   * Последняя отданная наружу разметка. Нужна, чтобы не переписывать
+   * contenteditable в ответ на собственное же обновление модели — иначе
+   * каждое нажатие клавиши сбрасывало бы каретку в начало.
+   */
+  const emitted = ref<string | null>(null);
+
+  const dialogShown = ref(false);
+  const dialogExtended = ref(false);
+  const editing = shallowRef<HTMLElement | null>(null);
+  const savedRange = shallowRef<Range | null>(null);
+  const form = reactive<DiceToken>(createDiceToken());
+
+  const dialogTitle = computed(() => {
+    if (editing.value) {
+      return 'Редактирование броска';
+    }
+
+    return dialogExtended.value ? 'Бросок' : 'Дайс';
+  });
+
+  // n-select с clearable отдаёт null, поэтому приводим значения формы вручную.
+  const trimmed = (value: string | null | undefined) => (value || '').trim();
+
+  const isFormValid = computed(() => !!trimmed(form.formula));
+
+  const syncFromModel = () => {
+    if (!editor.value) {
+      return;
+    }
+
+    editor.value.innerHTML = htmlToEditable(props.modelValue || '');
+  };
+
+  const emitValue = (value: string) => {
+    emitted.value = value;
+
+    emit('update:modelValue', value);
+  };
+
+  const emitFromEditor = () => {
+    if (!editor.value) {
+      return;
+    }
+
+    emitValue(editableToHtml(editor.value.innerHTML));
+  };
+
+  const onSourceInput = (event: Event) => {
+    if (event.target instanceof HTMLTextAreaElement) {
+      emitValue(event.target.value);
+    }
+  };
+
+  /**
+   * Последнее выделение внутри редактора. Дропдаун заголовков забирает фокус,
+   * поэтому команды форматирования восстанавливают выделение из него.
+   */
+  const lastRange = shallowRef<Range | null>(null);
+
+  const getRange = (): Range | null => {
+    const selection = window.getSelection();
+
+    if (selection?.rangeCount) {
+      const range = selection.getRangeAt(0);
+
+      if (editor.value?.contains(range.commonAncestorContainer)) {
+        return range;
+      }
+    }
+
+    return lastRange.value;
+  };
+
+  const rememberRange = () => {
+    const selection = window.getSelection();
+
+    if (!selection?.rangeCount) {
+      return;
+    }
+
+    const range = selection.getRangeAt(0);
+
+    if (editor.value?.contains(range.commonAncestorContainer)) {
+      lastRange.value = range.cloneRange();
+    }
+  };
+
+  const restoreRange = () => {
+    const range = lastRange.value;
+
+    if (!range) {
+      return;
+    }
+
+    try {
+      const selection = window.getSelection();
+
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    } catch {
+      lastRange.value = null;
+    }
+  };
+
+  const findToken = (range: Range | null): HTMLElement | null => {
+    const node = range?.startContainer;
+    const element = node instanceof Element ? node : node?.parentElement;
+    const token = element?.closest(`.${TOKEN_CLASS}`);
+
+    return token instanceof HTMLElement ? token : null;
+  };
+
+  const focusEditor = () => {
+    if (mode.value === 'html') {
+      editor.value?.focus();
+    }
+  };
+
+  const exec = (command: string) => {
+    if (props.disabled || mode.value !== 'html') {
+      return;
+    }
+
+    editor.value?.focus();
+    restoreRange();
+    document.execCommand(command);
+    rememberRange();
+    emitFromEditor();
+  };
+
+  /** Выравнивание пишем в `style`, а не в устаревший атрибут `align`. */
+  const align = (command: string) => {
+    if (props.disabled || mode.value !== 'html') {
+      return;
+    }
+
+    editor.value?.focus();
+    restoreRange();
+    document.execCommand('styleWithCSS', false, 'true');
+    document.execCommand(command);
+    document.execCommand('styleWithCSS', false, 'false');
+    rememberRange();
+    emitFromEditor();
+  };
+
+  const formatBlock = (tag: string) => {
+    if (props.disabled || mode.value !== 'html') {
+      return;
+    }
+
+    editor.value?.focus();
+    restoreRange();
+    document.execCommand('formatBlock', false, tag);
+    rememberRange();
+    emitFromEditor();
+  };
+
+  const openDialog = (extended: boolean, token: HTMLElement | null) => {
+    if (props.disabled || mode.value !== 'html') {
+      return;
+    }
+
+    const range = getRange();
+    const target = token || findToken(range);
+
+    editing.value = target;
+    savedRange.value = target ? null : range;
+    dialogExtended.value = extended;
+
+    if (target) {
+      Object.assign(form, tokenFromElement(target));
+
+      dialogExtended.value =
+        extended || form.variant !== 'dice' || !!form.label;
+    } else {
+      const selected = range?.toString().trim() || '';
+
+      Object.assign(
+        form,
+        createDiceToken({
+          formula: extractFormula(selected),
+          text: selected,
+          label: extended ? 'Бросок' : '',
+        }),
+      );
+    }
+
+    dialogShown.value = true;
+  };
+
+  const insertToken = (element: HTMLElement) => {
+    const range = savedRange.value;
+
+    if (!range) {
+      editor.value?.append(element);
+
+      return;
+    }
+
+    range.deleteContents();
+    range.insertNode(element);
+
+    const selection = window.getSelection();
+
+    range.setStartAfter(element);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  };
+
+  const applyToken = () => {
+    if (!isFormValid.value) {
+      return;
+    }
+
+    const element = createTokenElement(
+      createDiceToken({
+        ...form,
+        formula: trimmed(form.formula),
+        text: trimmed(form.text) || trimmed(form.formula),
+        label: trimmed(form.label),
+        source: trimmed(form.source),
+      }),
+    );
+
+    if (editing.value) {
+      editing.value.replaceWith(element);
+    } else {
+      insertToken(element);
+    }
+
+    dialogShown.value = false;
+    emitFromEditor();
+  };
+
+  const removeToken = () => {
+    editing.value?.remove();
+
+    dialogShown.value = false;
+    emitFromEditor();
+  };
+
+  const onEditorClick = (event: MouseEvent) => {
+    const { target } = event;
+
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const token = target.closest(`.${TOKEN_CLASS}`);
+
+    if (token instanceof HTMLElement) {
+      openDialog(false, token);
+    }
+  };
+
+  watch(
+    () => props.modelValue,
+    (value) => {
+      if (value !== emitted.value) {
+        syncFromModel();
+      }
+    },
+  );
+
+  watch(mode, async (value) => {
+    if (value === 'html') {
+      await nextTick();
+
+      syncFromModel();
+    }
+  });
+
+  onMounted(() => {
+    // Чтобы execCommand генерировал теги, а не inline-стили.
+    document.execCommand('styleWithCSS', false, 'false');
+
+    syncFromModel();
+  });
+</script>
+
+<template>
+  <div class="html-editor">
+    <div class="html-editor__toolbar">
+      <div class="html-editor__group">
+        <button
+          :disabled="disabled || mode === 'source'"
+          class="html-editor__button is-bold"
+          title="Жирный (Ctrl+B)"
+          type="button"
+          @click="exec('bold')"
+          @mousedown.prevent
+        >
+          Ж
+        </button>
+
+        <button
+          :disabled="disabled || mode === 'source'"
+          class="html-editor__button is-italic"
+          title="Курсив (Ctrl+I)"
+          type="button"
+          @click="exec('italic')"
+          @mousedown.prevent
+        >
+          К
+        </button>
+
+        <span class="html-editor__divider" />
+
+        <n-dropdown
+          :disabled="disabled || mode === 'source'"
+          :options="HEADING_OPTIONS"
+          trigger="click"
+          @select="formatBlock"
+        >
+          <button
+            :disabled="disabled || mode === 'source'"
+            class="html-editor__button"
+            title="Заголовок (H1–H5)"
+            type="button"
+            @mousedown.prevent
+          >
+            <icon
+              icon="tabler:heading"
+              width="18"
+              height="18"
+            />
+          </button>
+        </n-dropdown>
+
+        <button
+          v-for="item in LIST_BUTTONS"
+          :key="item.command"
+          :disabled="disabled || mode === 'source'"
+          :title="item.title"
+          class="html-editor__button"
+          type="button"
+          @click="exec(item.command)"
+          @mousedown.prevent
+        >
+          <icon
+            :icon="item.icon"
+            width="18"
+            height="18"
+          />
+        </button>
+
+        <span class="html-editor__divider" />
+
+        <button
+          v-for="item in ALIGN_BUTTONS"
+          :key="item.command"
+          :disabled="disabled || mode === 'source'"
+          :title="item.title"
+          class="html-editor__button"
+          type="button"
+          @click="align(item.command)"
+          @mousedown.prevent
+        >
+          <icon
+            :icon="item.icon"
+            width="18"
+            height="18"
+          />
+        </button>
+
+        <span class="html-editor__divider" />
+
+        <button
+          :disabled="disabled || mode === 'source'"
+          class="html-editor__button"
+          title="Дайс — кликабельная формула, например 2к6"
+          type="button"
+          @click="openDialog(false, null)"
+          @mousedown.prevent
+        >
+          <icon
+            icon="tabler:dice-5"
+            width="18"
+            height="18"
+          />
+        </button>
+
+        <button
+          :disabled="disabled || mode === 'source'"
+          class="html-editor__button"
+          title="Бросок — формула с подписью, преимуществом или спасброском"
+          type="button"
+          @click="openDialog(true, null)"
+          @mousedown.prevent
+        >
+          <icon
+            icon="tabler:dice-6-filled"
+            width="18"
+            height="18"
+          />
+        </button>
+      </div>
+
+      <div class="html-editor__group html-editor__group--modes">
+        <button
+          v-for="option in MODE_OPTIONS"
+          :key="option.value"
+          :class="{ 'is-active': mode === option.value }"
+          class="html-editor__button"
+          type="button"
+          @click="mode = option.value"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-show="mode === 'html'"
+      ref="editor"
+      :contenteditable="!disabled"
+      :data-placeholder="placeholder"
+      :style="{ minHeight: `${rows * 24}px` }"
+      aria-multiline="true"
+      class="html-editor__content"
+      role="textbox"
+      tabindex="0"
+      @click="onEditorClick"
+      @input="emitFromEditor"
+      @keyup="rememberRange"
+      @mouseup="rememberRange"
+    />
+
+    <textarea
+      v-show="mode === 'source'"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      :rows="rows"
+      :value="modelValue"
+      class="html-editor__source"
+      spellcheck="false"
+      @input="onSourceInput"
+    />
+
+    <!--
+      Проксирует нативную валидацию формы на contenteditable: сам он
+      required быть не может, поэтому за него отчитывается скрытое поле.
+    -->
+    <input
+      v-if="required"
+      :value="modelValue"
+      aria-hidden="true"
+      class="html-editor__validation"
+      required
+      tabindex="-1"
+      @focus="focusEditor"
+    />
+
+    <n-modal
+      v-model:show="dialogShown"
+      :title="dialogTitle"
+      :style="{ maxWidth: '480px' }"
+      preset="card"
+    >
+      <n-form
+        label-placement="top"
+        @submit.prevent="applyToken"
+      >
+        <n-form-item label="Формула">
+          <n-input
+            v-model:value="form.formula"
+            placeholder="2к6 + 3"
+          />
+        </n-form-item>
+
+        <n-form-item label="Текст">
+          <n-input
+            v-model:value="form.text"
+            placeholder="Совпадает с формулой"
+          />
+        </n-form-item>
+
+        <template v-if="dialogExtended">
+          <n-form-item label="Подпись">
+            <n-select
+              v-model:value="form.label"
+              :options="LABEL_OPTIONS"
+              clearable
+              filterable
+              placeholder="Бросок"
+              tag
+            />
+          </n-form-item>
+
+          <n-form-item label="Тип">
+            <n-radio-group v-model:value="form.variant">
+              <n-radio-button
+                v-for="option in VARIANT_OPTIONS"
+                :key="option.value"
+                :label="option.label"
+                :value="option.value"
+              />
+            </n-radio-group>
+          </n-form-item>
+
+          <n-form-item label="Источник">
+            <n-input
+              v-model:value="form.source"
+              placeholder="Необязательно"
+            />
+          </n-form-item>
+        </template>
+      </n-form>
+
+      <template #footer>
+        <div class="html-editor__modal-actions">
+          <n-button
+            v-if="editing"
+            type="error"
+            secondary
+            @click="removeToken"
+          >
+            Удалить
+          </n-button>
+
+          <n-button @click="dialogShown = false"> Отмена </n-button>
+
+          <n-button
+            :disabled="!isFormValid"
+            type="primary"
+            @click="applyToken"
+          >
+            {{ editing ? 'Сохранить' : 'Вставить' }}
+          </n-button>
+        </div>
+      </template>
+    </n-modal>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  @use '@/assets/styles/variables/mixins' as *;
+
+  .html-editor {
+    position: relative;
+
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+
+    &__toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: space-between;
+
+      padding: 6px 8px;
+
+      border-bottom: 1px solid var(--border);
+    }
+
+    &__group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      align-items: center;
+    }
+
+    &__button {
+      cursor: pointer;
+
+      display: inline-flex;
+      gap: 6px;
+      align-items: center;
+
+      min-height: 32px;
+      padding: 4px 10px;
+
+      font-size: calc(var(--main-font-size) - 1px);
+      color: var(--text-color);
+
+      background-color: transparent;
+      border: 1px solid transparent;
+      border-radius: 6px;
+
+      @include css-anim();
+
+      &:hover:not(:disabled) {
+        background-color: var(--hover);
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 50%;
+      }
+
+      &.is-active {
+        color: var(--text-btn-color);
+        background-color: var(--primary);
+      }
+
+      &.is-bold {
+        font-weight: 700;
+      }
+
+      &.is-italic {
+        font-style: italic;
+      }
+    }
+
+    &__divider {
+      align-self: stretch;
+      width: 1px;
+      margin: 4px 2px;
+      background-color: var(--border);
+    }
+
+    &__content,
+    &__source {
+      width: 100%;
+      padding: 10px 12px;
+      color: var(--text-b-color);
+    }
+
+    &__content {
+      overflow-y: auto;
+
+      &:focus-visible {
+        outline: none;
+      }
+
+      &:empty::before {
+        content: attr(data-placeholder);
+        color: var(--text-g-color);
+      }
+
+      // Внутри contenteditable нет глобальной типографики сайта,
+      // поэтому базовый вид блоков задаём здесь.
+      :deep(h1),
+      :deep(h2),
+      :deep(h3),
+      :deep(h4),
+      :deep(h5) {
+        margin: 8px 0;
+        font-weight: 600;
+        line-height: 1.25;
+      }
+
+      :deep(h1) {
+        font-size: 1.6em;
+      }
+
+      :deep(h2) {
+        font-size: 1.4em;
+      }
+
+      :deep(h3) {
+        font-size: 1.25em;
+      }
+
+      :deep(h4) {
+        font-size: 1.1em;
+      }
+
+      :deep(h5) {
+        font-size: 1em;
+      }
+
+      :deep(ul),
+      :deep(ol) {
+        margin: 8px 0;
+        padding-left: 24px;
+      }
+
+      :deep(ul) {
+        list-style: disc;
+      }
+
+      :deep(ol) {
+        list-style: decimal;
+      }
+
+      :deep(.html-editor-dice) {
+        cursor: pointer;
+        font-weight: 500;
+        white-space: nowrap;
+        border-bottom: 1px dashed currentcolor;
+
+        &.is-dice {
+          color: var(--bg-dice);
+        }
+
+        &.is-advantage {
+          color: var(--bg-advantage);
+        }
+
+        &.is-disadvantage {
+          color: var(--bg-disadvantage);
+        }
+
+        &.is-saving-throw {
+          color: var(--bg-saving-throw);
+        }
+      }
+    }
+
+    &__source {
+      resize: vertical;
+      font-family: monospace;
+      background-color: transparent;
+      border: 0;
+
+      &:focus-visible {
+        outline: none;
+      }
+    }
+
+    &__validation {
+      position: absolute;
+
+      width: 1px;
+      height: 1px;
+      padding: 0;
+
+      opacity: 0%;
+      border: 0;
+    }
+
+    &__modal-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+  }
+</style>

--- a/src/shared/ui/kit/html-editor/UiHtmlEditor.vue
+++ b/src/shared/ui/kit/html-editor/UiHtmlEditor.vue
@@ -3,6 +3,7 @@
 
   import {
     TOKEN_CLASS,
+    compressHtml,
     createDiceToken,
     createTokenElement,
     editableToHtml,
@@ -148,6 +149,16 @@
   const onSourceInput = (event: Event) => {
     if (event.target instanceof HTMLTextAreaElement) {
       emitValue(event.target.value);
+    }
+  };
+
+  /**
+   * Сжимаем не на каждый символ, а когда правка исходника закончена, —
+   * иначе разметку невозможно было бы форматировать при наборе.
+   */
+  const onSourceChange = (event: Event) => {
+    if (event.target instanceof HTMLTextAreaElement) {
+      emitValue(compressHtml(event.target.value));
     }
   };
 
@@ -535,6 +546,7 @@
       :value="modelValue"
       class="html-editor__source"
       spellcheck="false"
+      @change="onSourceChange"
       @input="onSourceInput"
     />
 

--- a/src/shared/ui/kit/html-editor/helpers.ts
+++ b/src/shared/ui/kit/html-editor/helpers.ts
@@ -1,0 +1,260 @@
+import type { DiceToken, DiceVariant } from './types';
+
+/** Тег, которым бросок хранится в описании. */
+export const DICE_TAG = 'dice-roller';
+
+/** Класс плейсхолдера броска внутри contenteditable. */
+export const TOKEN_CLASS = 'html-editor-dice';
+
+const VARIANT_ATTRS = {
+  'advantage': ['is-advantage', 'isadvantage'],
+  'disadvantage': ['is-disadvantage', 'isdisadvantage'],
+  'saving-throw': ['is-saving-throw', 'issavingthrow'],
+};
+
+/**
+ * Самозакрывающиеся кастомные теги (`<dice-roller formula="2к6"/>`) валидны
+ * для компилятора шаблонов Vue, но не для HTML-парсера: он считает такой тег
+ * открывающим и складывает в него весь последующий текст. Поэтому перед
+ * разбором приводим их к парному виду.
+ */
+const SELF_CLOSING_TAG =
+  /<([a-z][a-z\d]*-[a-z\d-]*)((?:"[^"]*"|'[^']*'|[^"'>])*?)\/>/gi;
+
+/** Формула кубика: `к6`, `2к6`, `1d20 + 5`. */
+const FORMULA = /\d*\s*[кkdд]\s*\d+(?:\s*[+-]\s*\d+)?/i;
+
+const INLINE_REPLACEMENTS = [
+  ['b', 'strong'],
+  ['i', 'em'],
+];
+
+/** Атрибуты, с которыми `<div>` всё ещё считается обычным абзацем. */
+const BLOCK_KEEP_ATTRS = ['style', 'align'];
+
+const expandSelfClosingTags = (html: string) =>
+  html.replace(
+    SELF_CLOSING_TAG,
+    (_match, tag: string, attrs: string) => `<${tag}${attrs}></${tag}>`,
+  );
+
+const parseHtml = (html: string) =>
+  new DOMParser().parseFromString(expandSelfClosingTags(html), 'text/html');
+
+const getAttr = (element: Element, name: string) =>
+  element.getAttribute(name) || '';
+
+const hasAnyAttribute = (element: Element, names: Array<string>) =>
+  names.some((name) => element.hasAttribute(name));
+
+const getVariant = (element: Element): DiceVariant => {
+  if (hasAnyAttribute(element, VARIANT_ATTRS.advantage)) {
+    return 'advantage';
+  }
+
+  if (hasAnyAttribute(element, VARIANT_ATTRS.disadvantage)) {
+    return 'disadvantage';
+  }
+
+  if (hasAnyAttribute(element, VARIANT_ATTRS['saving-throw'])) {
+    return 'saving-throw';
+  }
+
+  return 'dice';
+};
+
+const parseVariant = (value: string | undefined): DiceVariant => {
+  if (
+    value === 'advantage' ||
+    value === 'disadvantage' ||
+    value === 'saving-throw'
+  ) {
+    return value;
+  }
+
+  return 'dice';
+};
+
+const renameElement = (element: Element, tagName: string, doc: Document) => {
+  const replacement = doc.createElement(tagName);
+
+  for (const attribute of Array.from(element.attributes)) {
+    replacement.setAttribute(attribute.name, attribute.value);
+  }
+
+  replacement.append(...Array.from(element.childNodes));
+  element.replaceWith(replacement);
+};
+
+/** `<b>`/`<i>` от `execCommand` приводим к принятым в описаниях тегам. */
+const normalizeInlineTags = (root: HTMLElement, doc: Document) => {
+  for (const [from, to] of INLINE_REPLACEMENTS) {
+    for (const element of Array.from(root.querySelectorAll(from))) {
+      renameElement(element, to, doc);
+    }
+  }
+};
+
+/**
+ * Перенос строки в contenteditable — это `<div>`, в описаниях — `<p>`.
+ * Переименовываем только «служебные» блоки: свои `<div>` с классами
+ * (`table-responsive` и подобные) трогать нельзя, а `style` от выравнивания
+ * нужно сохранить.
+ */
+const normalizeBlocks = (root: HTMLElement, doc: Document) => {
+  for (const child of Array.from(root.children)) {
+    const onlyLayoutAttrs = Array.from(child.attributes).every((attr) =>
+      BLOCK_KEEP_ATTRS.includes(attr.name),
+    );
+
+    if (child.tagName === 'DIV' && onlyLayoutAttrs) {
+      renameElement(child, 'p', doc);
+    }
+  }
+};
+
+/**
+ * `execCommand` при вставке списков и заголовков оставляет вокруг них
+ * полностью пустые `<p></p>`. Пустую строку, набранную вручную, браузер
+ * сохраняет как `<p><br></p>` — её не трогаем.
+ */
+const removeEmptyParagraphs = (root: HTMLElement) => {
+  for (const element of Array.from(root.querySelectorAll('p'))) {
+    if (!element.childNodes.length) {
+      element.remove();
+    }
+  }
+};
+
+const cleanupAttributes = (root: HTMLElement) => {
+  for (const element of Array.from(
+    root.querySelectorAll('[contenteditable]'),
+  )) {
+    element.removeAttribute('contenteditable');
+  }
+};
+
+export const createDiceToken = (token: Partial<DiceToken> = {}): DiceToken => ({
+  formula: '',
+  text: '',
+  label: '',
+  source: '',
+  variant: 'dice',
+  ...token,
+});
+
+const tokenFromDiceRoller = (element: Element): DiceToken => {
+  const formula = getAttr(element, 'formula');
+
+  return createDiceToken({
+    formula,
+    text: element.textContent?.trim() || formula,
+    label: getAttr(element, 'label'),
+    source: getAttr(element, 'source'),
+    variant: getVariant(element),
+  });
+};
+
+export const tokenFromElement = (element: HTMLElement): DiceToken => {
+  const formula = element.dataset.formula || '';
+
+  return createDiceToken({
+    formula,
+    text: element.textContent?.trim() || formula,
+    label: element.dataset.label || '',
+    source: element.dataset.source || '',
+    variant: parseVariant(element.dataset.variant),
+  });
+};
+
+/** Плейсхолдер броска для визуального режима — неделимый и некликабельный. */
+export const createTokenElement = (
+  token: DiceToken,
+  doc: Document = document,
+): HTMLElement => {
+  const element = doc.createElement('span');
+
+  element.className = `${TOKEN_CLASS} is-${token.variant}`;
+  element.contentEditable = 'false';
+  element.dataset.formula = token.formula;
+  element.dataset.variant = token.variant;
+  element.dataset.label = token.label;
+  element.dataset.source = token.source;
+
+  element.title = token.label
+    ? `${token.label}: ${token.formula}`
+    : token.formula;
+  element.textContent = token.text || token.formula;
+
+  return element;
+};
+
+const createDiceRollerElement = (token: DiceToken, doc: Document): Element => {
+  const element = doc.createElement(DICE_TAG);
+
+  if (token.label) {
+    element.setAttribute('label', token.label);
+  }
+
+  element.setAttribute('formula', token.formula);
+
+  if (token.source) {
+    element.setAttribute('source', token.source);
+  }
+
+  if (token.variant !== 'dice') {
+    element.setAttribute(`is-${token.variant}`, '');
+  }
+
+  element.textContent = token.text || token.formula;
+
+  return element;
+};
+
+/** Разметка описания → разметка визуального редактора. */
+export const htmlToEditable = (html: string): string => {
+  if (!html.trim()) {
+    return '';
+  }
+
+  const doc = parseHtml(html);
+
+  for (const element of Array.from(doc.body.querySelectorAll(DICE_TAG))) {
+    element.replaceWith(createTokenElement(tokenFromDiceRoller(element), doc));
+  }
+
+  return doc.body.innerHTML;
+};
+
+/** Разметка визуального редактора → разметка описания. */
+export const editableToHtml = (html: string): string => {
+  if (!html.trim()) {
+    return '';
+  }
+
+  const doc = parseHtml(html);
+
+  for (const element of Array.from(
+    doc.body.querySelectorAll(`.${TOKEN_CLASS}`),
+  )) {
+    if (element instanceof HTMLElement) {
+      element.replaceWith(
+        createDiceRollerElement(tokenFromElement(element), doc),
+      );
+    }
+  }
+
+  normalizeInlineTags(doc.body, doc);
+  normalizeBlocks(doc.body, doc);
+  removeEmptyParagraphs(doc.body);
+  cleanupAttributes(doc.body);
+
+  return doc.body.innerHTML.trim();
+};
+
+/** Достаёт формулу из выделенного текста, например `урон 2к6 + 1` → `2к6 + 1`. */
+export const extractFormula = (text: string): string => {
+  const match = text.match(FORMULA);
+
+  return match ? match[0].replace(/\s+/g, ' ').trim() : '';
+};

--- a/src/shared/ui/kit/html-editor/helpers.ts
+++ b/src/shared/ui/kit/html-editor/helpers.ts
@@ -32,6 +32,50 @@ const INLINE_REPLACEMENTS = [
 /** Атрибуты, с которыми `<div>` всё ещё считается обычным абзацем. */
 const BLOCK_KEEP_ATTRS = ['style', 'align'];
 
+/**
+ * Блочные теги: пробелы и переносы рядом с ними на отображение не влияют,
+ * поэтому при сжатии их можно убирать полностью. Между инлайновыми тегами
+ * пробел значим (`<strong>а</strong> <em>б</em>`) — там оставляем один.
+ */
+const BLOCK_TAGS = [
+  'ARTICLE',
+  'BLOCKQUOTE',
+  'BR',
+  'CAPTION',
+  'COL',
+  'COLGROUP',
+  'DIV',
+  'FIGURE',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'HR',
+  'LI',
+  'OL',
+  'P',
+  'SECTION',
+  'TABLE',
+  'TBODY',
+  'TD',
+  'TFOOT',
+  'TH',
+  'THEAD',
+  'TR',
+  'UL',
+];
+
+/** Теги, внутри которых пробелы значимы и сжимать их нельзя. */
+const PRESERVE_WHITESPACE = 'pre, code, textarea';
+
+/**
+ * Пробельные символы, кроме неразрывного: `&nbsp;` в описаниях ставят
+ * намеренно (`СЛ&nbsp;15`, `10&nbsp;футов`), схлопывать его нельзя.
+ */
+const COLLAPSIBLE_SPACE = /[^\S\u00A0]+/g;
+
 const expandSelfClosingTags = (html: string) =>
   html.replace(
     SELF_CLOSING_TAG,
@@ -124,6 +168,68 @@ const removeEmptyParagraphs = (root: HTMLElement) => {
       element.remove();
     }
   }
+};
+
+const isBlockNode = (node: Node | null) =>
+  !!node &&
+  node.nodeType === Node.ELEMENT_NODE &&
+  BLOCK_TAGS.includes(node.nodeName);
+
+/**
+ * Схлопывает отступы и переносы строк: браузер их всё равно не отображает,
+ * а в базе они раздувают описание. Пробел между инлайновыми тегами значим,
+ * поэтому он сохраняется — убираются только «оформительские» пробелы
+ * на границах блоков.
+ */
+const collapseWhitespace = (root: HTMLElement, doc: Document) => {
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes: Array<Text> = [];
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+
+    if (node instanceof Text) {
+      nodes.push(node);
+    }
+  }
+
+  for (const node of nodes) {
+    if (node.parentElement?.closest(PRESERVE_WHITESPACE)) {
+      continue;
+    }
+
+    let text = node.data.replace(COLLAPSIBLE_SPACE, ' ');
+
+    if (isBlockNode(node.previousSibling) || !node.previousSibling) {
+      text = text.replace(/^ /, '');
+    }
+
+    if (isBlockNode(node.nextSibling) || !node.nextSibling) {
+      text = text.replace(/ $/, '');
+    }
+
+    if (text) {
+      node.data = text;
+    } else {
+      node.remove();
+    }
+  }
+};
+
+/**
+ * Приводит разметку к компактному виду. Идемпотентна: сжатый HTML
+ * проходит через неё без изменений.
+ */
+export const compressHtml = (html: string): string => {
+  if (!html.trim()) {
+    return '';
+  }
+
+  const doc = parseHtml(html);
+
+  collapseWhitespace(doc.body, doc);
+
+  return doc.body.innerHTML.trim();
 };
 
 const cleanupAttributes = (root: HTMLElement) => {
@@ -248,6 +354,7 @@ export const editableToHtml = (html: string): string => {
   normalizeBlocks(doc.body, doc);
   removeEmptyParagraphs(doc.body);
   cleanupAttributes(doc.body);
+  collapseWhitespace(doc.body, doc);
 
   return doc.body.innerHTML.trim();
 };

--- a/src/shared/ui/kit/html-editor/index.ts
+++ b/src/shared/ui/kit/html-editor/index.ts
@@ -1,0 +1,3 @@
+export { default as UiHtmlEditor } from './UiHtmlEditor.vue';
+
+export * from './types';

--- a/src/shared/ui/kit/html-editor/types.ts
+++ b/src/shared/ui/kit/html-editor/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Вид броска — соответствует модификаторам компонента `DiceRoller`.
+ * `dice` — обычный дайс, остальные добавляют флаг `is-*` в разметку.
+ */
+export type DiceVariant =
+  | 'dice'
+  | 'advantage'
+  | 'disadvantage'
+  | 'saving-throw';
+
+/** Данные тега `<dice-roller>` внутри описания. */
+export interface DiceToken {
+  /** Формула броска, например `2к6 + 3`. */
+  formula: string;
+  /** Текст, который видит пользователь. По умолчанию совпадает с формулой. */
+  text: string;
+  /** Подпись броска в уведомлении (`Атака`, `Урон` и т.д.). */
+  label: string;
+  /** Источник броска в уведомлении. */
+  source: string;
+  variant: DiceVariant;
+}
+
+/** Режим редактора: визуальный или правка исходного кода. */
+export type HtmlEditorMode = 'html' | 'source';


### PR DESCRIPTION
## Что сделано

HTML-редактор для полей описаний в мастерской вместо простых `textarea`.

### Компонент

`src/shared/ui/kit/html-editor` — `UiHtmlEditor` с переключением между визуальным режимом и исходным кодом.

Тулбар:

- жирный и курсив;
- заголовки H1–H5;
- маркированный и нумерованный списки;
- выравнивание влево, по центру, вправо;
- вставка дайса и броска.

Броски хранятся в разметке как `dice-roller` — в том же формате, который генерирует бэкенд (`MarkdownUtil`), поэтому старые описания открываются и сохраняются без потерь. В визуальном режиме они показываются цветными неделимыми плашками: клик открывает правку или удаление. Формула подставляется из выделенного текста автоматически.

Для броска доступны подпись, источник и тип — обычный, преимущество, помеха, спасбросок; тип пишется флагом `is-*`.

### Сжатие разметки

Отступы и переносы схлопываются при сохранении: браузер их всё равно не отображает, а в базе они раздувают описание. Сжатие идёт через DOM, поэтому значимые пробелы остаются на месте — между инлайновыми тегами, внутри `pre` и `code`, а также неразрывные, которые в описаниях ставят намеренно (`СЛ&nbsp;15`).

Исходный код сжимается по завершении правки, а не на каждый символ, чтобы не мешать форматировать при наборе.

### Где подключено

Все HTML-поля редакторов мастерской: описания в 13 редакторах, а также «На больших уровнях» у заклинаний, «Особое» у оружия, «Персонализация» у предысторий, «Свободный текст реакций» у существ, «Доспехи», «Оружие», «Инструменты» и «Снаряжение» у классов, описания архетипов и умений.

Построчные блоки бестиария — реакции, легендарные и мистические действия — намеренно оставлены обычными `textarea`: у них свой формат «название / значение», который HTML-редактор бы сломал.

Заодно убраны нумерованные подписи текстовых блоков в бестиарии («Особенности #1», «Действия #1»).

## Проверка

- Разметка проходит полный круг без потерь: таблицы, `strong`/`em`, самозакрывающиеся `dice-roller`, флаги `is-*`, неразрывные пробелы. Повторный проход ничего не меняет.
- Результат корректно рендерится через реальные `RawContent` и `DiceRoller` — булевы атрибуты доезжают как `true`.
- Проверены вставка, правка и удаление броска, переключение режимов, заголовки, списки и выравнивание.
- `eslint`, `stylelint` и `vue-tsc` по изменённым файлам чистые.

## Отдельно стоит посмотреть

- Валидация: `contenteditable` не может быть `required`, поэтому за него отчитывается скрытое зеркало-поле. Там, где `required` был у `textarea`, он сохранён.
- Визуальный режим разбирает разметку через `DOMParser`. Описания с выражениями Vue безопаснее править в «Исходном коде».
